### PR TITLE
Allow script to be run directly using `uv run`

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#   "requests<3",
+#   "mcp<2",
+# ]
+# ///
+
 from mcp.server.fastmcp import FastMCP
 import requests
 


### PR DESCRIPTION
Adds metadata to allow `uv run bridge_mcp_ghidra.py` to automatically download the required dependencies

EDIT:
I just realized this is actually a Python standard ( https://peps.python.org/pep-0723/#example ) and not just the format that `uv` uses. This means it should actually work with other package managers in the future.