### PR TITLE
Allow the Ghidra URL to be controlled via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To set up Claude Desktop as a Ghidra MCP client, go to `Claude` -> `Settings` ->
 ```
 
 Alternatively, edit this file directly:
+
 ```
 /Users/YOUR_USER/Library/Application Support/Claude/claude_desktop_config.json
 ```
@@ -87,3 +88,9 @@ The generated zip file includes the built Ghidra plugin and its resources. These
 - lib/GhidraMCP.jar
 - extensions.properties
 - Module.manifest
+
+# Configuration
+
+Specify the `GHIDRA_SERVER_URL` to configure what Ghidra instance is controlled by this plugin.
+
+Defaults to `http://localhost:8080`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ The generated zip file includes the built Ghidra plugin and its resources. These
 
 # Configuration
 
-Specify the `GHIDRA_SERVER_URL` to configure what Ghidra instance is controlled by this plugin.
+Specify the `GHIDRA_SERVER_URL` environment variable to configure what Ghidra instance is controlled by this MCP server, otherwise the server defaults to `http://localhost:8080`
 
-Defaults to `http://localhost:8080`
+You can include environment variables in the MCP config json like so:
+
+
+```json
+{
+  "mcpServers": {
+    "ghidra": {
+      "command": "python",
+      "args": [
+        "/ABSOLUTE_PATH_TO/bridge_mcp_ghidra.py"
+      ],
+      "env": {
+        "GHIDRA_SERVER_URL": "https://your-ghidra-url/"
+      }
+    }
+  }
+}
+```
+

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1,7 +1,8 @@
 from mcp.server.fastmcp import FastMCP
 import requests
+import os
 
-ghidra_server_url = "http://localhost:8080"
+ghidra_server_url = os.getenv("GHIDRA_SERVER_URL", "http://localhost:8080")
 
 mcp = FastMCP("ghidra-mcp")
 


### PR DESCRIPTION
I thought I'd add this so you can easily direct the GhidraMCP at other Ghidra instance(s), or default to localhost:8080

I didn't see any other obvious things to control via environment variables or I would include them here. 