### PR TITLE
Update bridge to take Ghidra endpoint as an argument, add PEP 723 metadata

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "mcp==1.5.0",
+#     "requests==2.32.3",
+# ]
+# ///
 import sys
 import requests
 

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1,7 +1,10 @@
-from mcp.server.fastmcp import FastMCP
+import sys
 import requests
 
-ghidra_server_url = "http://localhost:8080"
+from mcp.server.fastmcp import FastMCP
+
+DEFAULT_GHIDRA_SERVER = "http://127.0.0.1:8080/"
+ghidra_server_url = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_GHIDRA_SERVER
 
 mcp = FastMCP("ghidra-mcp")
 

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -10,18 +10,15 @@ mcp = FastMCP("ghidra-mcp")
 
 def safe_get(endpoint: str, params: dict = None) -> list:
     """
-    Perform a GET request. If 'params' is given, we convert it to a query string.
+    Perform a GET request with optional query parameters.
     """
     if params is None:
         params = {}
-    qs = [f"{k}={v}" for k, v in params.items()]
-    query_string = "&".join(qs)
+
     url = f"{ghidra_server_url}/{endpoint}"
-    if query_string:
-        url += "?" + query_string
 
     try:
-        response = requests.get(url, timeout=5)
+        response = requests.get(url, params=params, timeout=5)
         response.encoding = 'utf-8'
         if response.ok:
             return response.text.splitlines()


### PR DESCRIPTION
This is needed to get the connection to work under WSL with Ghidra running in Windows, or for settings where Ghidra runs remotely. To use, add the additional arg to the mcp Configuration, such as

```json
{
  "mcpServers": {
    "ghidra": {
      "command": "python",
      "args": [
        "/path/to/bridge_mcp_ghidra.py",
        "http://172.18.0.1:8080/"
      ],
      "disabled": false,
      "autoApprove": []
    }
  }
}
```