### PR TITLE
Added local variable and parameter renaming

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -120,6 +120,16 @@ def search_functions_by_name(query: str, offset: int = 0, limit: int = 100) -> l
         return ["Error: query string is required"]
     return safe_get("searchFunctions", {"query": query, "offset": offset, "limit": limit})
 
+@mcp.tool()
+def rename_variable(function_name: str, old_name: str, new_name: str) -> str:
+    """
+    Rename a local variable within a function.
+    """
+    return safe_post("renameVariable", {
+        "functionName": function_name,
+        "oldName": old_name,
+        "newName": new_name
+    })
 
 if __name__ == "__main__":
     mcp.run()

--- a/src/main/java/com/lauriewired/GhidraMCPPlugin.java
+++ b/src/main/java/com/lauriewired/GhidraMCPPlugin.java
@@ -7,6 +7,11 @@ import ghidra.program.model.address.GlobalNamespace;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.program.model.symbol.*;
+import ghidra.program.model.pcode.HighFunction;
+import ghidra.program.model.pcode.HighSymbol;
+import ghidra.program.model.pcode.LocalSymbolMap;
+import ghidra.program.model.pcode.HighFunctionDBUtil;
+import ghidra.program.model.pcode.HighFunctionDBUtil.ReturnCommitOption;
 import ghidra.app.decompiler.DecompInterface;
 import ghidra.app.decompiler.DecompileResults;
 import ghidra.app.plugin.PluginCategoryNames;
@@ -85,6 +90,15 @@ public class GhidraMCPPlugin extends Plugin {
             Map<String, String> params = parsePostParams(exchange);
             renameDataAtAddress(params.get("address"), params.get("newName"));
             sendResponse(exchange, "Rename data attempted");
+        });
+
+        server.createContext("/renameVariable", exchange -> {
+            Map<String, String> params = parsePostParams(exchange);
+            String functionName = params.get("functionName");
+            String oldName = params.get("oldName");
+            String newName = params.get("newName");
+            String result = renameVariableInFunction(functionName, oldName, newName);
+            sendResponse(exchange, result);
         });
 
         server.createContext("/segments", exchange -> {
@@ -357,6 +371,131 @@ public class GhidraMCPPlugin extends Plugin {
             Msg.error(this, "Failed to execute rename data on Swing thread", e);
         }
     }
+
+    private String renameVariableInFunction(String functionName, String oldVarName, String newVarName) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+
+        DecompInterface decomp = new DecompInterface();
+        decomp.openProgram(program);
+
+        Function func = null;
+        for (Function f : program.getFunctionManager().getFunctions(true)) {
+            if (f.getName().equals(functionName)) {
+                func = f;
+                break;
+            }
+        }
+
+        if (func == null) {
+            return "Function not found";
+        }
+
+        DecompileResults result = decomp.decompileFunction(func, 30, new ConsoleTaskMonitor());
+        if (result == null || !result.decompileCompleted()) {
+            return "Decompilation failed";
+        }
+
+        HighFunction highFunction = result.getHighFunction();
+        if (highFunction == null) {
+            return "Decompilation failed (no high function)";
+        }
+
+        LocalSymbolMap localSymbolMap = highFunction.getLocalSymbolMap();
+        if (localSymbolMap == null) {
+            return "Decompilation failed (no local symbol map)";
+        }
+
+        HighSymbol highSymbol = null;
+        Iterator<HighSymbol> symbols = localSymbolMap.getSymbols();
+        while (symbols.hasNext()) {
+            HighSymbol symbol = symbols.next();
+            String symbolName = symbol.getName();
+            
+            if (symbolName.equals(oldVarName)) {
+                highSymbol = symbol;
+            }
+            if (symbolName.equals(newVarName)) {
+                return "Error: A variable with name '" + newVarName + "' already exists in this function";
+            }
+        }
+
+        if (highSymbol == null) {
+            return "Variable not found";
+        }
+
+        boolean commitRequired = checkFullCommit(highSymbol, highFunction);
+
+        final HighSymbol finalHighSymbol = highSymbol;
+        final Function finalFunction = func;
+        AtomicBoolean successFlag = new AtomicBoolean(false);
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {           
+                int tx = program.startTransaction("Rename variable");
+                try {
+                    if (commitRequired) {
+                        HighFunctionDBUtil.commitParamsToDatabase(highFunction, false,
+                            ReturnCommitOption.NO_COMMIT, finalFunction.getSignatureSource());
+                    }
+                    HighFunctionDBUtil.updateDBVariable(
+                        finalHighSymbol,
+                        newVarName,
+                        null,
+                        SourceType.USER_DEFINED
+                    );
+                    successFlag.set(true);
+                }
+                catch (Exception e) {
+                    Msg.error(this, "Failed to rename variable", e);
+                }
+                finally {
+                    program.endTransaction(tx, true);
+                }
+            });
+        } catch (InterruptedException | InvocationTargetException e) {
+            String errorMsg = "Failed to execute rename on Swing thread: " + e.getMessage();
+            Msg.error(this, errorMsg, e);
+            return errorMsg;
+        }
+        return successFlag.get() ? "Variable renamed" : "Failed to rename variable";
+    }
+
+    /**
+     * Copied from AbstractDecompilerAction.checkFullCommit, it's protected.
+	 * Compare the given HighFunction's idea of the prototype with the Function's idea.
+	 * Return true if there is a difference. If a specific symbol is being changed,
+	 * it can be passed in to check whether or not the prototype is being affected.
+	 * @param highSymbol (if not null) is the symbol being modified
+	 * @param hfunction is the given HighFunction
+	 * @return true if there is a difference (and a full commit is required)
+	 */
+	protected static boolean checkFullCommit(HighSymbol highSymbol, HighFunction hfunction) {
+		if (highSymbol != null && !highSymbol.isParameter()) {
+			return false;
+		}
+		Function function = hfunction.getFunction();
+		Parameter[] parameters = function.getParameters();
+		LocalSymbolMap localSymbolMap = hfunction.getLocalSymbolMap();
+		int numParams = localSymbolMap.getNumParams();
+		if (numParams != parameters.length) {
+			return true;
+		}
+
+		for (int i = 0; i < numParams; i++) {
+			HighSymbol param = localSymbolMap.getParamSymbol(i);
+			if (param.getCategoryIndex() != i) {
+				return true;
+			}
+			VariableStorage storage = param.getStorage();
+			// Don't compare using the equals method so that DynamicVariableStorage can match
+			if (0 != storage.compareTo(parameters[i].getVariableStorage())) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 
     // ----------------------------------------------------------------------------------
     // Utility: parse query params, parse post params, pagination, etc.


### PR DESCRIPTION
Closes #11

As Laurie alluded to in the linked issue, figuring out the way to go about this was not obvious, until I looked at what code runs when you rename a variable in the GUI and found the `RenameVariableTask` class.

I'm not sure what operation I can perform that would make `checkFullCommit` to return true, but I cargo-culted the checks because the original function we're copying does them.
Either way, in my testing the rename operation worked correctly, even before I added the check/commit part.