### PR TITLE
ci: Create build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GHIDRA_VERSION: 11.3.1
+      GHIDRA_DATE: 20250219
+      GHIDRA_LIBS: >-
+        Features/Base/lib/Base.jar
+        Features/Decompiler/lib/Decompiler.jar
+        Framework/Docking/lib/Docking.jar
+        Framework/Generic/lib/Generic.jar
+        Framework/Project/lib/Project.jar
+        Framework/SoftwareModeling/lib/SoftwareModeling.jar
+        Framework/Utility/lib/Utility.jar
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Download Ghidra
+      run: |
+        wget --no-verbose -O ghidra.zip https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${{ env.GHIDRA_VERSION }}_build/ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC_${{ env.GHIDRA_DATE }}.zip
+        7z x -bd ghidra.zip
+
+    - name: Copy Ghidra libs
+      run: |
+        mkdir ./lib
+        for libfile in ${{ env.GHIDRA_LIBS }}
+          do echo "Copying ${libfile} to lib/"
+          cp ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC/Ghidra/${libfile} ./lib/
+        done
+
+    - name: Build with Maven
+      run: mvn clean package assembly:single
+
+    - name: Assemble release directory
+      run: |
+        mkdir release
+        cp target/GhidraMCP-*-SNAPSHOT.zip release/
+        cp bridge_mcp_ghidra.py release/
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: GhidraMCP-artifact
+        path: |
+          release/*


### PR DESCRIPTION
Adding a GitHub Actions workflow to build the project using Maven.

The workflow is triggered by pushes and pull requests to the `main` branch. 

- Temurin distribution of JDK 21 is used.
- Downloads Ghidra and copies the required libs to the `lib/` folder
- Assembles the release directory with the build artifacts.
- Uploads the build artifacts as a GitHub Actions artifact.

### Requirements for New Ghidra Version

When a new version of Ghidra is released or utilized, the following updates are required in the workflow:

1. Update the `GHIDRA_VERSION` environment variable to the new Ghidra version number.
2. Update the `GHIDRA_DATE` environment variable to the release date of the new Ghidra version.
3. Verify and update the paths of the Ghidra libraries listed under the `GHIDRA_LIBS` environment variable if there are any changes in the new version.

PS: Here is an example run: https://github.com/tuxuser/GhidraMCP/actions/runs/14183238001