### PR TITLE
Utilize urljoin to gracefully handle variations of server name strings

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -8,6 +8,7 @@
 
 import sys
 import requests
+from urllib.parse import urljoin
 
 from mcp.server.fastmcp import FastMCP
 
@@ -23,7 +24,7 @@ def safe_get(endpoint: str, params: dict = None) -> list:
     if params is None:
         params = {}
 
-    url = f"{ghidra_server_url}/{endpoint}"
+    url =  urljoin(ghidra_server_url, endpoint)
 
     try:
         response = requests.get(url, params=params, timeout=5)
@@ -38,9 +39,9 @@ def safe_get(endpoint: str, params: dict = None) -> list:
 def safe_post(endpoint: str, data: dict | str) -> str:
     try:
         if isinstance(data, dict):
-            response = requests.post(f"{ghidra_server_url}/{endpoint}", data=data, timeout=5)
+            response = requests.post( urljoin(ghidra_server_url, endpoint), data=data, timeout=5)
         else:
-            response = requests.post(f"{ghidra_server_url}/{endpoint}", data=data.encode("utf-8"), timeout=5)
+            response = requests.post( urljoin(ghidra_server_url, endpoint), data=data.encode("utf-8"), timeout=5)
         response.encoding = 'utf-8'
         if response.ok:
             return response.text.strip()


### PR DESCRIPTION
Thanks so much for the time and effort you put into this, Laurie, and for sharing it with us all!

I was having trouble getting the MCP server to communicate with both Claude and 5ire on Windows with repeated `404` responses, so I took a look and realized that if a user keeps the default server string (`https://127.0.0.1:8080/`, note the trailing `/`), or adds their own with a trailing slash, it makes for bad HTTP requests due to the doubled `//`:

```http
GET //methods?offset=0&limit=100 HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: python-requests/2.31.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive

HTTP/1.1 404 Not Found
Content-Length: 50
Content-Type: text/html
Connection: close

<h1>404 Not Found</h1>No context found for request
```

To handle this more gracefully, I'm proposing the use of `urljoin` from `urllib.parse` to handle server strings both with and without trailing slashes:

```bash
>>> from urllib.parse import urljoin
>>> server_no_slash = "https://127.0.0.1:8080"
>>> server_slash = server_no_slash + '/'
>>> endpoint = "methods"
>>> urljoin(server_no_slash, endpoint)
'https://127.0.0.1:8080/methods'
>>> urljoin(server_slash, endpoint)
'https://127.0.0.1:8080/methods'
>>> urljoin(server_slash, endpoint) == urljoin(server_no_slash, endpoint)
True
```

After this change:

```http
GET /methods?offset=0&limit=100 HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: python-requests/2.31.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive

HTTP/1.1 200 OK
Date: Sun, 13 Apr 2025 05:45:02 GMT
Content-type: text/plain; charset=utf-8
Content-length: 1287

FUN_00401000
FUN_0040117d
FUN_004011ef
...
```

Please reach out if you have any questions or feedback