### PR TITLE
Remove trailing slash in Ghidra server URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To set up Claude Desktop as a Ghidra MCP client, go to `Claude` -> `Settings` ->
       "args": [
         "/ABSOLUTE_PATH_TO/bridge_mcp_ghidra.py",
         "--ghidra-server",
-        "http://127.0.0.1:8080/"
+        "http://127.0.0.1:8080"
       ]
     }
   }
@@ -79,7 +79,7 @@ The server IP and port are configurable and should be set to point to the target
 To use GhidraMCP with [Cline](https://cline.bot), this requires manually running the MCP server as well. First run the following command:
 
 ```
-python bridge_mcp_ghidra.py --transport sse --mcp-host 127.0.0.1 --mcp-port 8081 --ghidra-server http://127.0.0.1:8080/
+python bridge_mcp_ghidra.py --transport sse --mcp-host 127.0.0.1 --mcp-port 8081 --ghidra-server http://127.0.0.1:8080
 ```
 
 The only *required* argument is the transport. If all other arguments are unspecified, they will default to the above. Once the MCP server is running, open up Cline and select `MCP Servers` at the top.

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -13,7 +13,7 @@ import logging
 
 from mcp.server.fastmcp import FastMCP
 
-DEFAULT_GHIDRA_SERVER = "http://127.0.0.1:8080/"
+DEFAULT_GHIDRA_SERVER = "http://127.0.0.1:8080"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
On my setup (Ubuntu 24.04, Ghidra 11.3, claude-desktop-debian) the Ghidra server was accessed with URLs like this one:

`http://127.0.0.1:8080//list_functions`

The Ghidra server returns 404 for these double-slashed URLs. This PR fixes default URL and documentation URLs.