### PR TITLE
[docs] add VSCode copilot instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Another MCP client that supports multiple models on the backend is [5ire](https:
 3. Command: `python /ABSOLUTE_PATH_TO/bridge_mcp_ghidra.py`
 
 ## Example 4: VSCode (GitHub Copilot)
-GitHub Copilot's agent mode can connect to MCP servers over both stdio and sse. To set up GhidraMCP as a "tool" in VSCode's Copilot chat, you need to first make sure you are in "Agent" mode. Then, click on the gears icon in the chat box:
+GitHub Copilot's agent mode can connect to MCP servers over both stdio and sse. To set up GhidraMCP as a "tool" in VSCode's Copilot chat, you need to first make sure you are in "Agent" mode. Then, click on the tools icon in the chat box:
 
 ![image](https://github.com/user-attachments/assets/096c9639-c0f3-4217-bdab-f2a0f364ac9c)
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ Another MCP client that supports multiple models on the backend is [5ire](https:
 2. Name: GhidraMCP
 3. Command: `python /ABSOLUTE_PATH_TO/bridge_mcp_ghidra.py`
 
+## Example 4: VSCode (GitHub Copilot)
+GitHub Copilot's agent mode can connect to MCP servers over both stdio and sse. To set up GhidraMCP as a "tool" in VSCode's Copilot chat, you need to first make sure you are in "Agent" mode. Then, click on the gears icon in the chat box:
+
+![image](https://github.com/user-attachments/assets/096c9639-c0f3-4217-bdab-f2a0f364ac9c)
+
+In the drop down menu that appears, select "Add More Tools" and then "Add MCP Server"
+
+![image](https://github.com/user-attachments/assets/9c7482d1-5cc5-4fa2-9bf4-e47b2a352304)
+
+Select "Command (stdio)" and enter `python3 C:\path\to\bridge_mcp_ghidra.py --ghidra-server http://localhost:8080/` as the command. Make sure to replace the path to the Python script with the actual path on your machine.
+
+![image](https://github.com/user-attachments/assets/400ae37c-4b9f-4101-a52b-eb316b09411d)
+
+![image](https://github.com/user-attachments/assets/c57e510e-6ac5-436a-a560-44949d04eed3)
+
+Lastly, give your MCP connection a name for VSCode.
+
+![image](https://github.com/user-attachments/assets/e1f58c66-8c20-4f05-aa3a-392724c383b0)
+
 # Building from Source
 1. Copy the following files from your Ghidra directory to this project's `lib/` directory:
 - `Ghidra/Features/Base/lib/Base.jar`


### PR DESCRIPTION
Added setup instructions to the README that demonstrates how to set up this MCP server with GitHub Copilot in Agent mode. Includes screenshots for each step.

Thanks for this cool project!