### PR TITLE
Add constants information from decompiler in Ghidra server response

### DIFF
--- a/src/main/java/com/lauriewired/GhidraMCPPlugin.java
+++ b/src/main/java/com/lauriewired/GhidraMCPPlugin.java
@@ -17,6 +17,7 @@ import ghidra.program.model.pcode.LocalSymbolMap;
 import ghidra.program.model.pcode.HighFunctionDBUtil;
 import ghidra.program.model.pcode.HighFunctionDBUtil.ReturnCommitOption;
 import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileOptions;
 import ghidra.app.decompiler.DecompileResults;
 import ghidra.app.plugin.PluginCategoryNames;
 import ghidra.app.services.CodeViewerService;
@@ -494,6 +495,9 @@ public class GhidraMCPPlugin extends Plugin {
         Program program = getCurrentProgram();
         if (program == null) return "No program loaded";
         DecompInterface decomp = new DecompInterface();
+        DecompileOptions options = new DecompileOptions();
+        options.setRespectReadOnly(true);
+        decomp.setOptions(options);
         decomp.openProgram(program);
         for (Function func : program.getFunctionManager().getFunctions(true)) {
             if (func.getName().equals(name)) {


### PR DESCRIPTION
For now it seems like current `decompileFunctionByName` is making a call with default `ReadOnly` value equal to `false`, resulting in no-known constants used output

```
  log_file = fopen(DAT_000acb30,DAT_000acb34);
  if (log_file != (FILE *)0x0) {
    fprintf(log_file,DAT_000acb38,DAT_000acb3c);
    fprintf(log_file,DAT_000acb40,deviceIdentifier,action);
    fclose(log_file);
  }
```

Enabling the flag results in output with string and other constants actually used

```
  log_file = fopen("/tmp/usb.log","a+");
  if (log_file != (FILE *)0x0) {
    fprintf(log_file,"[usb_dbg: %s] ","asus_sg");
    fprintf(log_file,"(%s): action=%s.\n",deviceIdentifier,action);
    fclose(log_file);
  }
```

which allows LLM (especially locally-run ones) to make more accurate guesses for variable/function renaming.