### PR TITLE
feat(mcp): Add read_bytes and write_bytes memory manipulation endpoints

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -287,6 +287,34 @@ def list_strings(offset: int = 0, limit: int = 2000, filter: str = None) -> list
         params["filter"] = filter
     return safe_get("strings", params)
 
+@mcp.tool()
+def read_bytes(address: str, length: int = 32) -> str:
+    """
+    Read raw bytes from memory at the given address.
+
+    Args:
+        address: Starting address in hex (e.g. "0x00401000")
+        length: Number of bytes to read (default: 32)
+
+    Returns:
+        Hex string of the bytes, space-separated (e.g. "55 8b ec ...")
+    """
+    return safe_get("read_bytes", {"address": address, "length": length})
+
+@mcp.tool()
+def write_bytes(address: str, bytes_hex: str) -> str:
+    """
+    Scrive una sequenza di byte all'indirizzo specificato nella memoria del programma.
+
+    Args:
+        address: Indirizzo di destinazione (es. "0x140001000")
+        bytes_hex: Sequenza di byte separati da spazi in formato esadecimale (es. "90 90 90 90")
+
+    Returns:
+        Risultato dell'operazione (es. "Bytes written successfully" oppure errore dettagliato)
+    """
+    return safe_post("write_bytes", {"address": address, "bytes": bytes_hex})
+
 def main():
     parser = argparse.ArgumentParser(description="MCP server for Ghidra")
     parser.add_argument("--ghidra-server", type=str, default=DEFAULT_GHIDRA_SERVER,

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -304,14 +304,14 @@ def read_bytes(address: str, length: int = 32) -> str:
 @mcp.tool()
 def write_bytes(address: str, bytes_hex: str) -> str:
     """
-    Scrive una sequenza di byte all'indirizzo specificato nella memoria del programma.
+    Writes a sequence of bytes to the specified address in the program's memory.
 
     Args:
-        address: Indirizzo di destinazione (es. "0x140001000")
-        bytes_hex: Sequenza di byte separati da spazi in formato esadecimale (es. "90 90 90 90")
+        address: Destination address (e.g., "0x140001000")
+        bytes_hex: Sequence of space-separated bytes in hexadecimal format (e.g., "90 90 90 90")
 
     Returns:
-        Risultato dell'operazione (es. "Bytes written successfully" oppure errore dettagliato)
+        Result of the operation (e.g., "Bytes written successfully" or a detailed error)
     """
     return safe_post("write_bytes", {"address": address, "bytes": bytes_hex})
 

--- a/src/main/java/com/lauriewired/GhidraMCPPlugin.java
+++ b/src/main/java/com/lauriewired/GhidraMCPPlugin.java
@@ -17,6 +17,7 @@ import ghidra.app.decompiler.DecompileResults;
 import ghidra.app.plugin.PluginCategoryNames;
 import ghidra.app.services.CodeViewerService;
 import ghidra.app.services.ProgramManager;
+import ghidra.program.disassemble.Disassembler;
 import ghidra.app.util.PseudoDisassembler;
 import ghidra.app.cmd.function.SetVariableNameCmd;
 import ghidra.util.exception.DuplicateNameException;
@@ -428,6 +429,8 @@ public class GhidraMCPPlugin extends Plugin {
                 try {
                     currentProgram.getListing().clearCodeUnits(address, endAddress, false);
                     memory.setBytes(address, newBytes);
+                    Disassembler disassembler = Disassembler.getDisassembler(currentProgram, TaskMonitor.DUMMY, null);
+                    disassembler.disassemble(address, null);
                     success = true;
                 } finally {
                     currentProgram.endTransaction(txId, success);


### PR DESCRIPTION
This commit introduces two new endpoints to the GhidraMCP plugin that enable reading and writing raw bytes directly from and to the program memory.

These endpoints provide essential low-level capabilities that are useful for scripting, static analysis, or creating custom tools that interact with the memory space of the currently loaded binary.

---

### New features:

- `/read_bytes`: Read a specified number of bytes starting from a given memory address (default: 32 bytes).
  
- `/write_bytes`: Write a sequence of bytes (hexadecimal, space-separated) to a given memory address.
  

### Technical Details:

- **read_bytes**:
  - Parameters: `address` (hex string), `length` (optional, default: 32)
  - Returns: Space-separated hex bytes
- **write_bytes**:
  - Parameters: `address` (hex string), `bytes_hex` (space-separated hex)
  - Returns: Success/error status

---

### Practical use case:

In my case, I used these tools to experiment with an old game binary and implement some basic memory patches—essentially small cheats—by reading and replacing instructions at runtime. These endpoints made it simple to inspect memory and modify behaviors live from external scripts.

##### Example:

Below are two examples showing practical usage of the new endpoints during the reverse engineering of a small game:

##### Context:

<img width="545" alt="Image1" src="https://github.com/user-attachments/assets/b80ccee0-20af-403e-abbe-88e9a4f54fcf" />

---

#### Reading memory with `/read_bytes`

In the following image, the LLM uses the `/read_bytes` endpoint to inspect a code block in memory that performs a lives check and reset. This lets it identify the `JLE +0x24` conditional jump that it later modify:

<img width="554" alt="Image2" src="https://github.com/user-attachments/assets/50f16e2a-b749-46e2-8940-bee365860b44" />


---

#### Patching memory with `/write_bytes`

Here, LLM uses the `/write_bytes` endpoint to overwrite the `JLE` instruction (`7e 24`) with an unconditional `JMP` (`eb 24`), effectively bypassing the lives limit check and creating an "infinite lives" condition:

<img width="451" alt="Image3" src="https://github.com/user-attachments/assets/28d290c0-28c7-4aac-b33b-1174060f5599" />

<img width="455" alt="Image4" src="https://github.com/user-attachments/assets/53184edb-be46-4c36-87be-76e727db0d8e" />


---

### Result

The ability to patch live code in memory from outside Ghidra through simple HTTP calls opens up a wide range of automation and experimentation possibilities—including, in my case, quick prototyping of memory cheats for legacy games

---

### Additional changes:

Added an overloaded `sendResponse(HttpExchange, String, int)` to return custom status codes (e.g., 400/405).

---

### Security Considerations:

- These endpoints modify program memory directly
- Intended for reverse engineering and analysis purposes
- Use with caution on production systems
