### PR TITLE
Add packaging and CI release workflow for the Python GhidraMCP client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to PyPI"
+        type: boolean
+        required: false
+        default: false
+      pretend_version:
+        description: "Override detected version (e.g. 1.4.1) for build only"
+        type: string
+        required: false
+  push:
+    tags:
+      - "*.*"
+      - "*.*.*"
+
+jobs:
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Build wheel
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.pretend_version }}
+        run: |
+          pip install build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Show built distributions
+        run: ls -1 dist
+
+      - name: Upload Python package dist artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: python-package-dist
+          path: dist
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: build-wheel
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ghidramcp
+    permissions:
+      id-token: write
+    steps:
+      - name: Download Python package dist artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: python-package-dist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ mvnw.cmd
 .env
 .env.*
 
+# Python things
+.venv
+venv
+dist
+
 # Java crash logs (if any)
 hs_err_pid*
 replay_pid*

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video Installation Guide:
 
 https://github.com/user-attachments/assets/75f0c176-6da1-48dc-ad96-c182eb4648c3
 
-
+The Python MCP client can be installed with either `pipx install GhidraMCP` or `uv tool install GhidraMCP`.
 
 ## MCP Clients
 
@@ -75,12 +75,21 @@ Alternatively, edit this file directly:
 
 The server IP and port are configurable and should be set to point to the target Ghidra instance. If not set, both will default to localhost:8080.
 
+If the GhidraMCP Python client was installed with `pipx` or `uv tool`, the first argument can be replaced with `bridge_mcp_ghidra` instead of giving an absolute path.
+
 ## Example 2: Cline
 To use GhidraMCP with [Cline](https://cline.bot), this requires manually running the MCP server as well. First run the following command:
 
 ```
 python bridge_mcp_ghidra.py --transport sse --mcp-host 127.0.0.1 --mcp-port 8081 --ghidra-server http://127.0.0.1:8080/
 ```
+
+Or if the GhidraMCP Python client was installed with `pipx` or `uv tool`:
+
+```
+bridge_mcp_ghidra --transport sse --mcp-host 127.0.0.1 --mcp-port 8081 --ghidra-server http://127.0.0.1:8080/
+```
+
 
 The only *required* argument is the transport. If all other arguments are unspecified, they will default to the above. Once the MCP server is running, open up Cline and select `MCP Servers` at the top.
 
@@ -97,6 +106,8 @@ Another MCP client that supports multiple models on the backend is [5ire](https:
 1. Tool Key: ghidra
 2. Name: GhidraMCP
 3. Command: `python /ABSOLUTE_PATH_TO/bridge_mcp_ghidra.py`
+
+If the GhidraMCP Python client was installed with `pipx` or `uv tool`, the command can be `bridge_mcp_ghidra` without needing to specify the python interpreter or giving an absolute path.
 
 # Building from Source
 1. Copy the following files from your Ghidra directory to this project's `lib/` directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["hatchling>=1.20", "hatch-vcs>=0.5.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ghidramcp"
+dynamic = ["version"]
+description = "Model Context Protocol server for Ghidra reverse engineering"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+    {name = "LaurieWired"}
+]
+keywords = ["ghidra", "reverse-engineering", "mcp", "model-context-protocol"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Disassemblers",
+]
+dependencies = [
+    "mcp>=1.2.0,<2",
+    "requests>=2,<3",
+]
+
+[project.urls]
+Homepage = "https://github.com/LaurieWired/GhidraMCP"
+Repository = "https://github.com/LaurieWired/GhidraMCP"
+Issues = "https://github.com/LaurieWired/GhidraMCP/issues"
+
+[project.scripts]
+bridge_mcp_ghidra = "bridge_mcp_ghidra:main"
+
+[tool.hatch.build]
+include = [
+    "bridge_mcp_ghidra.py",
+    "README.md",
+    "LICENSE",
+]
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "(?P<version>\\d+\\.\\d+(?:\\.\\d+)?)"
+fallback-version = "0.0"
+
+[tool.hatch.build.targets.wheel]
+only-include = [
+    "bridge_mcp_ghidra.py"
+]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "bridge_mcp_ghidra.py",
+    "README.md",
+    "LICENSE",
+]


### PR DESCRIPTION
This adds files for publishing a copy of the Python MCP client/server on PyPI, so it can be installed with `pipx` or `uv tool install` -- this removes the need for absolute paths in configuration files for claude/5ire/etc and the explicit `python` command to run the script. It is also makes it possible for other Python tools to list it as a dependency.

Currently this PR has CI workflows set up to publish new releases when a new git tags that looks like a version number is pushed. Once (if? I could keep maintaining this packaging myself as a separate repo) this change is merged I can update the PyPI trusted publishing workflow to use this GitHub repo (and add/transfer ownership of the PyPI package if desired).

* Add pyproject.toml using Hatchling + hatch-vcs for packaging GhidraMCP's Python client; version pulled from Git tags (no v prefix), CLI entrypoint defined for running the Python MCP client
* Add release workflow to build/check wheel, upload artifacts, and publish to PyPI using OIDC
* Update README to mention ways to install GhidraMCP Python client using pipx and uv tool

cc: @LaurieWired 