### PR TITLE
feat: add multi-instance support with port scanning

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -17,6 +17,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_excep
 from mcp.server.fastmcp import FastMCP
 
 DEFAULT_GHIDRA_SERVER = "http://127.0.0.1:8080/"
+PORT_RANGE = range(8080, 8090)
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,38 @@ mcp = FastMCP("ghidra-mcp")
 
 # Initialize ghidra_server_url with default value
 ghidra_server_url = DEFAULT_GHIDRA_SERVER
+
+# Multi-instance support
+active_instances = {}  # Maps program name -> {"port": int, "url": str}
+primary_port = 8080
+
+def discover_instances():
+    """Scan port range to discover active Ghidra instances."""
+    global active_instances, primary_port
+    instances = {}
+    for port in PORT_RANGE:
+        try:
+            url = f"http://127.0.0.1:{port}/"
+            response = httpx.get(urljoin(url, "get_current_address"), timeout=1.0)
+            if response.status_code == 200:
+                program_name = f"program@{port}"
+                instances[program_name] = {"port": port, "url": url}
+                if not active_instances:
+                    primary_port = port
+        except:
+            continue
+    active_instances = instances
+    return instances
+
+def get_instance_url(target_binary=None):
+    """Get the base URL for the target binary instance."""
+    if target_binary and target_binary in active_instances:
+        return active_instances[target_binary]["url"]
+    if target_binary:
+        discover_instances()
+        if target_binary in active_instances:
+            return active_instances[target_binary]["url"]
+    return f"http://127.0.0.1:{primary_port}/"
 
 # HTTP client with connection pooling
 _http_client = None
@@ -43,14 +76,14 @@ def get_http_client():
     retry=retry_if_exception_type((httpx.ConnectError, httpx.ConnectTimeout)),
     reraise=True,
 )
-def safe_get(endpoint: str, params: dict = None) -> list:
+def safe_get(endpoint: str, params: dict = None, target_binary: str = None) -> list:
     """
     Perform a GET request with optional query parameters.
     """
     if params is None:
         params = {}
 
-    url = urljoin(ghidra_server_url, endpoint)
+    url = urljoin(get_instance_url(target_binary), endpoint)
 
     try:
         response = get_http_client().get(url, params=params)
@@ -68,9 +101,9 @@ def safe_get(endpoint: str, params: dict = None) -> list:
     retry=retry_if_exception_type((httpx.ConnectError, httpx.ConnectTimeout)),
     reraise=True,
 )
-def safe_post(endpoint: str, data: dict | str) -> str:
+def safe_post(endpoint: str, data: dict | str, target_binary: str = None) -> str:
     try:
-        url = urljoin(ghidra_server_url, endpoint)
+        url = urljoin(get_instance_url(target_binary), endpoint)
         if isinstance(data, dict):
             response = get_http_client().post(url, data=data)
         else:
@@ -84,174 +117,207 @@ def safe_post(endpoint: str, data: dict | str) -> str:
         return f"Request failed: {str(e)}"
 
 @mcp.tool()
-def list_methods(offset: int = 0, limit: int = 100) -> list:
+def list_ghidra_instances() -> list:
+    """
+    List all active Ghidra instances.
+    Use this to find which target_binary values are available.
+    """
+    instances = discover_instances()
+    return [{"target_binary": name, "port": info["port"], "url": info["url"]} 
+            for name, info in instances.items()]
+
+@mcp.tool()
+def list_methods(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List all function names in the program with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("methods", {"offset": offset, "limit": limit})
+    return safe_get("methods", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def list_classes(offset: int = 0, limit: int = 100) -> list:
+def list_classes(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List all namespace/class names in the program with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("classes", {"offset": offset, "limit": limit})
+    return safe_get("classes", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def decompile_function(name: str) -> str:
+def decompile_function(name: str, target_binary: str = None) -> str:
     """
     Decompile a specific function by name and return the decompiled C code.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("decompile", name)
+    return safe_post("decompile", name, target_binary)
 
 @mcp.tool()
-def rename_function(old_name: str, new_name: str) -> str:
+def rename_function(old_name: str, new_name: str, target_binary: str = None) -> str:
     """
     Rename a function by its current name to a new user-defined name.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("renameFunction", {"oldName": old_name, "newName": new_name})
+    return safe_post("renameFunction", {"oldName": old_name, "newName": new_name}, target_binary)
 
 @mcp.tool()
-def rename_data(address: str, new_name: str) -> str:
+def rename_data(address: str, new_name: str, target_binary: str = None) -> str:
     """
     Rename a data label at the specified address.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("renameData", {"address": address, "newName": new_name})
+    return safe_post("renameData", {"address": address, "newName": new_name}, target_binary)
 
 @mcp.tool()
-def list_segments(offset: int = 0, limit: int = 100) -> list:
+def list_segments(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List all memory segments in the program with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("segments", {"offset": offset, "limit": limit})
+    return safe_get("segments", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def list_imports(offset: int = 0, limit: int = 100) -> list:
+def list_imports(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List imported symbols in the program with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("imports", {"offset": offset, "limit": limit})
+    return safe_get("imports", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def list_exports(offset: int = 0, limit: int = 100) -> list:
+def list_exports(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List exported functions/symbols with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("exports", {"offset": offset, "limit": limit})
+    return safe_get("exports", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def list_namespaces(offset: int = 0, limit: int = 100) -> list:
+def list_namespaces(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List all non-global namespaces in the program with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("namespaces", {"offset": offset, "limit": limit})
+    return safe_get("namespaces", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def list_data_items(offset: int = 0, limit: int = 100) -> list:
+def list_data_items(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List defined data labels and their values with pagination.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("data", {"offset": offset, "limit": limit})
+    return safe_get("data", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def search_functions_by_name(query: str, offset: int = 0, limit: int = 100) -> list:
+def search_functions_by_name(query: str, offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     Search for functions whose name contains the given substring.
+    Provide target_binary if multiple Ghidra windows are open.
     """
     if not query:
         return ["Error: query string is required"]
-    return safe_get("searchFunctions", {"query": query, "offset": offset, "limit": limit})
+    return safe_get("searchFunctions", {"query": query, "offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def rename_variable(function_name: str, old_name: str, new_name: str) -> str:
+def rename_variable(function_name: str, old_name: str, new_name: str, target_binary: str = None) -> str:
     """
     Rename a local variable within a function.
+    Provide target_binary if multiple Ghidra windows are open.
     """
     return safe_post("renameVariable", {
         "functionName": function_name,
         "oldName": old_name,
         "newName": new_name
-    })
+    }, target_binary)
 
 @mcp.tool()
-def get_function_by_address(address: str) -> str:
+def get_function_by_address(address: str, target_binary: str = None) -> str:
     """
     Get a function by its address.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return "\n".join(safe_get("get_function_by_address", {"address": address}))
+    return "\n".join(safe_get("get_function_by_address", {"address": address}, target_binary))
 
 @mcp.tool()
-def get_current_address() -> str:
+def get_current_address(target_binary: str = None) -> str:
     """
     Get the address currently selected by the user.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return "\n".join(safe_get("get_current_address"))
+    return "\n".join(safe_get("get_current_address", None, target_binary))
 
 @mcp.tool()
-def get_current_function() -> str:
+def get_current_function(target_binary: str = None) -> str:
     """
     Get the function currently selected by the user.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return "\n".join(safe_get("get_current_function"))
+    return "\n".join(safe_get("get_current_function", None, target_binary))
 
 @mcp.tool()
-def list_functions() -> list:
+def list_functions(offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     List all functions in the database.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("list_functions")
+    return safe_get("list_functions", {"offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def decompile_function_by_address(address: str) -> str:
+def decompile_function_by_address(address: str, target_binary: str = None) -> str:
     """
     Decompile a function at the given address.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return "\n".join(safe_get("decompile_function", {"address": address}))
+    return "\n".join(safe_get("decompile_function", {"address": address}, target_binary))
 
 @mcp.tool()
-def disassemble_function(address: str) -> list:
+def disassemble_function(address: str, target_binary: str = None) -> list:
     """
     Get assembly code (address: instruction; comment) for a function.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_get("disassemble_function", {"address": address})
+    return safe_get("disassemble_function", {"address": address}, target_binary)
 
 @mcp.tool()
-def set_decompiler_comment(address: str, comment: str) -> str:
+def set_decompiler_comment(address: str, comment: str, target_binary: str = None) -> str:
     """
     Set a comment for a given address in the function pseudocode.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("set_decompiler_comment", {"address": address, "comment": comment})
+    return safe_post("set_decompiler_comment", {"address": address, "comment": comment}, target_binary)
 
 @mcp.tool()
-def set_disassembly_comment(address: str, comment: str) -> str:
+def set_disassembly_comment(address: str, comment: str, target_binary: str = None) -> str:
     """
     Set a comment for a given address in the function disassembly.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("set_disassembly_comment", {"address": address, "comment": comment})
+    return safe_post("set_disassembly_comment", {"address": address, "comment": comment}, target_binary)
 
 @mcp.tool()
-def rename_function_by_address(function_address: str, new_name: str) -> str:
+def rename_function_by_address(function_address: str, new_name: str, target_binary: str = None) -> str:
     """
     Rename a function by its address.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("rename_function_by_address", {"function_address": function_address, "new_name": new_name})
+    return safe_post("rename_function_by_address", {"function_address": function_address, "new_name": new_name}, target_binary)
 
 @mcp.tool()
-def set_function_prototype(function_address: str, prototype: str) -> str:
+def set_function_prototype(function_address: str, prototype: str, target_binary: str = None) -> str:
     """
     Set a function's prototype.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("set_function_prototype", {"function_address": function_address, "prototype": prototype})
+    return safe_post("set_function_prototype", {"function_address": function_address, "prototype": prototype}, target_binary)
 
 @mcp.tool()
-def set_local_variable_type(function_address: str, variable_name: str, new_type: str) -> str:
+def set_local_variable_type(function_address: str, variable_name: str, new_type: str, target_binary: str = None) -> str:
     """
     Set a local variable's type.
+    Provide target_binary if multiple Ghidra windows are open.
     """
-    return safe_post("set_local_variable_type", {"function_address": function_address, "variable_name": variable_name, "new_type": new_type})
+    return safe_post("set_local_variable_type", {"function_address": function_address, "variable_name": variable_name, "new_type": new_type}, target_binary)
 
 @mcp.tool()
-def get_xrefs_to(address: str, offset: int = 0, limit: int = 100) -> list:
+def get_xrefs_to(address: str, offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     Get all references to the specified address (xref to).
     
@@ -259,14 +325,15 @@ def get_xrefs_to(address: str, offset: int = 0, limit: int = 100) -> list:
         address: Target address in hex format (e.g. "0x1400010a0")
         offset: Pagination offset (default: 0)
         limit: Maximum number of references to return (default: 100)
+        target_binary: Target Ghidra instance (from list_ghidra_instances)
         
     Returns:
         List of references to the specified address
     """
-    return safe_get("xrefs_to", {"address": address, "offset": offset, "limit": limit})
+    return safe_get("xrefs_to", {"address": address, "offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def get_xrefs_from(address: str, offset: int = 0, limit: int = 100) -> list:
+def get_xrefs_from(address: str, offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     Get all references from the specified address (xref from).
     
@@ -274,14 +341,15 @@ def get_xrefs_from(address: str, offset: int = 0, limit: int = 100) -> list:
         address: Source address in hex format (e.g. "0x1400010a0")
         offset: Pagination offset (default: 0)
         limit: Maximum number of references to return (default: 100)
+        target_binary: Target Ghidra instance (from list_ghidra_instances)
         
     Returns:
         List of references from the specified address
     """
-    return safe_get("xrefs_from", {"address": address, "offset": offset, "limit": limit})
+    return safe_get("xrefs_from", {"address": address, "offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def get_function_xrefs(name: str, offset: int = 0, limit: int = 100) -> list:
+def get_function_xrefs(name: str, offset: int = 0, limit: int = 100, target_binary: str = None) -> list:
     """
     Get all references to the specified function by name.
     
@@ -289,14 +357,15 @@ def get_function_xrefs(name: str, offset: int = 0, limit: int = 100) -> list:
         name: Function name to search for
         offset: Pagination offset (default: 0)
         limit: Maximum number of references to return (default: 100)
+        target_binary: Target Ghidra instance (from list_ghidra_instances)
         
     Returns:
         List of references to the specified function
     """
-    return safe_get("function_xrefs", {"name": name, "offset": offset, "limit": limit})
+    return safe_get("function_xrefs", {"name": name, "offset": offset, "limit": limit}, target_binary)
 
 @mcp.tool()
-def list_strings(offset: int = 0, limit: int = 2000, filter: str = None) -> list:
+def list_strings(offset: int = 0, limit: int = 2000, filter: str = None, target_binary: str = None) -> list:
     """
     List all defined strings in the program with their addresses.
     
@@ -304,6 +373,7 @@ def list_strings(offset: int = 0, limit: int = 2000, filter: str = None) -> list
         offset: Pagination offset (default: 0)
         limit: Maximum number of strings to return (default: 2000)
         filter: Optional filter to match within string content
+        target_binary: Target Ghidra instance (from list_ghidra_instances)
         
     Returns:
         List of strings with their addresses
@@ -311,7 +381,7 @@ def list_strings(offset: int = 0, limit: int = 2000, filter: str = None) -> list
     params = {"offset": offset, "limit": limit}
     if filter:
         params["filter"] = filter
-    return safe_get("strings", params)
+    return safe_get("strings", params, target_binary)
 
 def main():
     parser = argparse.ArgumentParser(description="MCP server for Ghidra")
@@ -326,9 +396,25 @@ def main():
     args = parser.parse_args()
     
     # Use the global variable to ensure it's properly updated
-    global ghidra_server_url
+    global ghidra_server_url, primary_port
     if args.ghidra_server:
         ghidra_server_url = args.ghidra_server
+        try:
+            from urllib.parse import urlparse
+            parsed = urlparse(args.ghidra_server)
+            if parsed.port:
+                primary_port = parsed.port
+        except:
+            pass
+    
+    # Discover instances on startup
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Discovering Ghidra instances...")
+    instances = discover_instances()
+    if instances:
+        logger.info(f"Found {len(instances)} instance(s): {list(instances.keys())}")
+    else:
+        logger.info("No active instances found, using default port")
     
     if args.transport == "sse":
         try:


### PR DESCRIPTION
## tl,dr
Add support for multiple simultaneous Ghidra instances via port scanning and target_binary routing.
## Background
When reverse engineering, it's common to have multiple binaries open in separate Ghidra windows (e.g., a main executable and its DLLs). Currently the bridge only talks to one instance. This PR enables targeting specific instances.
## Changes
- Scan ports 8080-8089 on startup to discover active Ghidra instances
- Add `list_ghidra_instances()` tool to enumerate available instances
- Add `target_binary` parameter to all tools for explicit instance routing
- Auto-discover instances and log findings on startup
## Testing
- Verified with single instance (backward compatible, no `target_binary` needed)
- Tested with two Ghidra instances on ports 8080 and 8081
- Confirmed `list_ghidra_instances()` returns both, and `target_binary` routes correctly