### PR TITLE
Add data manipulation, batch operations, and type system endpoints

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -57,6 +57,25 @@ def safe_post(endpoint: str, data: dict | str) -> str:
     except Exception as e:
         return f"Request failed: {str(e)}"
 
+def safe_post_json(endpoint: str, json_data) -> str:
+    """
+    Perform a POST request with a JSON body.
+    """
+    import json
+    try:
+        url = urljoin(ghidra_server_url, endpoint)
+        body = json.dumps(json_data) if not isinstance(json_data, str) else json_data
+        response = requests.post(url, data=body.encode("utf-8"),
+                                 headers={"Content-Type": "application/json"},
+                                 timeout=30)
+        response.encoding = 'utf-8'
+        if response.ok:
+            return response.text.strip()
+        else:
+            return f"Error {response.status_code}: {response.text.strip()}"
+    except Exception as e:
+        return f"Request failed: {str(e)}"
+
 @mcp.tool()
 def list_methods(offset: int = 0, limit: int = 100) -> list:
     """
@@ -286,6 +305,113 @@ def list_strings(offset: int = 0, limit: int = 2000, filter: str = None) -> list
     if filter:
         params["filter"] = filter
     return safe_get("strings", params)
+
+@mcp.tool()
+def clear_data(address: str, size: int = None) -> str:
+    """
+    Clear (undefine) data at an address, reverting bytes to undefined state.
+    If size is omitted, clears the single data item at that address.
+    """
+    data = {"address": address}
+    if size is not None:
+        data["size"] = str(size)
+    return safe_post("clear_data", data)
+
+@mcp.tool()
+def define_data(address: str, data_type: str, label: str = None) -> str:
+    """
+    Create a data definition at an address. Supported types: byte, word, dword, qword,
+    float, double, pointer, char, or any type in the data type manager.
+    Optionally assign a label/symbol name.
+    """
+    data = {"address": address, "data_type": data_type}
+    if label:
+        data["label"] = label
+    return safe_post("define_data", data)
+
+@mcp.tool()
+def define_data_batch(items: list[dict]) -> str:
+    """
+    Create multiple data definitions in a single transaction.
+    Each item: {"address": "0x...", "data_type": "dword", "label": "optional_name"}
+    """
+    return safe_post_json("define_data_batch", items)
+
+@mcp.tool()
+def read_bytes(address: str, length: int) -> str:
+    """
+    Read raw bytes from memory at a given address. Returns hex-encoded string.
+    """
+    return safe_get("read_bytes", {"address": address, "length": length})
+
+@mcp.tool()
+def get_data_at(address: str) -> str:
+    """
+    Get detailed info about the data item at a specific address:
+    type, size, label, value, and containing item info.
+    """
+    return safe_get("get_data_at", {"address": address})
+
+@mcp.tool()
+def batch_rename_functions(renames: list[dict]) -> str:
+    """
+    Rename multiple functions in one transaction.
+    Each item: {"address": "0x...", "new_name": "MyFunction"}
+    """
+    return safe_post_json("batch_rename_functions", renames)
+
+@mcp.tool()
+def batch_set_comments(comments: list[dict], comment_type: str = "decompiler") -> str:
+    """
+    Set multiple comments in one transaction.
+    comment_type: "decompiler" (PRE_COMMENT) or "disassembly" (EOL_COMMENT).
+    Each comment: {"address": "0x...", "comment": "text"}
+    """
+    return safe_post_json("batch_set_comments", {
+        "comment_type": comment_type,
+        "comments": comments
+    })
+
+@mcp.tool()
+def create_label(address: str, name: str, namespace: str = None) -> str:
+    """
+    Create a label/symbol at any address (code, data, or undefined bytes).
+    """
+    data = {"address": address, "name": name}
+    if namespace:
+        data["namespace"] = namespace
+    return safe_post("create_label", data)
+
+@mcp.tool()
+def create_enum(name: str, values: list[dict], size: int = 4) -> str:
+    """
+    Create an enum data type. Each value: {"name": "MEMBER_NAME", "value": 0}
+    """
+    return safe_post_json("create_enum", {
+        "name": name,
+        "size": size,
+        "values": values
+    })
+
+@mcp.tool()
+def create_struct(name: str, fields: list[dict]) -> str:
+    """
+    Create a structure data type.
+    Each field: {"name": "field_name", "type": "int", "size": 4}
+    If size is omitted, the type's natural size is used.
+    """
+    return safe_post_json("create_struct", {
+        "name": name,
+        "fields": fields
+    })
+
+@mcp.tool()
+def apply_struct(address: str, struct_name: str) -> str:
+    """
+    Apply a previously created struct type at a memory address.
+    Clears existing data at the address range and stamps the struct.
+    """
+    return safe_post("apply_struct", {"address": address, "struct_name": struct_name})
 
 def main():
     parser = argparse.ArgumentParser(description="MCP server for Ghidra")

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,15 @@
       <systemPath>${project.basedir}/lib/Gui.jar</systemPath>
     </dependency>
 
+    <!-- Gson for JSON parsing (bundled with Ghidra) -->
+    <dependency>
+      <groupId>com.google.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.9.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/lib/gson.jar</systemPath>
+    </dependency>
+
     <!-- JUnit (test only) -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/lauriewired/GhidraMCPPlugin.java
+++ b/src/main/java/com/lauriewired/GhidraMCPPlugin.java
@@ -2243,7 +2243,17 @@ public class GhidraMCPPlugin extends Plugin {
 
     public Program getCurrentProgram() {
         ProgramManager pm = tool.getService(ProgramManager.class);
-        return pm != null ? pm.getCurrentProgram() : null;
+        if (pm != null && pm.getCurrentProgram() != null) {
+            return pm.getCurrentProgram();
+        }
+        // ProgramManager returns null when plugin is loaded via Code Browser
+        // instead of a tool that directly provides ProgramManager. Fall back
+        // to CodeViewerService which is always available in Code Browser.
+        CodeViewerService cvs = tool.getService(CodeViewerService.class);
+        if (cvs != null && cvs.getNavigatable() != null) {
+            return cvs.getNavigatable().getProgram();
+        }
+        return null;
     }
 
     private void sendResponse(HttpExchange exchange, String response) throws IOException {

--- a/src/main/java/com/lauriewired/GhidraMCPPlugin.java
+++ b/src/main/java/com/lauriewired/GhidraMCPPlugin.java
@@ -38,8 +38,17 @@ import ghidra.program.model.pcode.HighVariable;
 import ghidra.program.model.pcode.Varnode;
 import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.DataTypeManager;
+import ghidra.program.model.data.DataTypeConflictHandler;
 import ghidra.program.model.data.PointerDataType;
 import ghidra.program.model.data.Undefined1DataType;
+import ghidra.program.model.data.EnumDataType;
+import ghidra.program.model.data.StructureDataType;
+import ghidra.program.model.data.CategoryPath;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import ghidra.program.model.listing.Variable;
 import ghidra.app.decompiler.component.DecompilerUtils;
 import ghidra.app.decompiler.ClangToken;
@@ -57,6 +66,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @PluginInfo(
     status = PluginStatus.RELEASED,
@@ -339,6 +349,85 @@ public class GhidraMCPPlugin extends Plugin {
             int limit = parseIntOrDefault(qparams.get("limit"), 100);
             String filter = qparams.get("filter");
             sendResponse(exchange, listDefinedStrings(offset, limit, filter));
+        });
+
+        server.createContext("/clear_data", exchange -> {
+            Map<String, String> params = parsePostParams(exchange);
+            String address = params.get("address");
+            String size = params.get("size");
+            String result = clearData(address, size);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/define_data", exchange -> {
+            Map<String, String> params = parsePostParams(exchange);
+            String address = params.get("address");
+            String dataType = params.get("data_type");
+            String label = params.get("label");
+            String result = defineData(address, dataType, label);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/define_data_batch", exchange -> {
+            String body = readRequestBody(exchange);
+            String result = defineDataBatch(body);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/read_bytes", exchange -> {
+            Map<String, String> qparams = parseQueryParams(exchange);
+            String address = qparams.get("address");
+            String length = qparams.get("length");
+            String result = readBytes(address, length);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/get_data_at", exchange -> {
+            Map<String, String> qparams = parseQueryParams(exchange);
+            String address = qparams.get("address");
+            String result = getDataAt(address);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/batch_rename_functions", exchange -> {
+            String body = readRequestBody(exchange);
+            String result = batchRenameFunctions(body);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/batch_set_comments", exchange -> {
+            String body = readRequestBody(exchange);
+            String result = batchSetComments(body);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/create_label", exchange -> {
+            Map<String, String> params = parsePostParams(exchange);
+            String address = params.get("address");
+            String name = params.get("name");
+            String namespace = params.get("namespace");
+            String result = createLabel(address, name, namespace);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/create_enum", exchange -> {
+            String body = readRequestBody(exchange);
+            String result = createEnum(body);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/create_struct", exchange -> {
+            String body = readRequestBody(exchange);
+            String result = createStruct(body);
+            sendResponse(exchange, result);
+        });
+
+        server.createContext("/apply_struct", exchange -> {
+            Map<String, String> params = parsePostParams(exchange);
+            String address = params.get("address");
+            String structName = params.get("struct_name");
+            String result = applyStruct(address, structName);
+            sendResponse(exchange, result);
         });
 
         server.setExecutor(null);
@@ -1474,6 +1563,14 @@ public class GhidraMCPPlugin extends Plugin {
             case "ulonglong":
             case "unsigned __int64":
                 return dtm.getDataType("/ulonglong");
+            case "float":
+                return dtm.getDataType("/float");
+            case "double":
+                return dtm.getDataType("/double");
+            case "qword":
+                return dtm.getDataType("/longlong");
+            case "pointer":
+                return new PointerDataType();
             case "bool":
             case "boolean":
                 return dtm.getDataType("/bool");
@@ -1527,6 +1624,519 @@ public class GhidraMCPPlugin extends Plugin {
         return null;
     }
 
+    private String clearData(String addressStr, String sizeStr) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (addressStr == null || addressStr.isEmpty()) return "Address is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to clear data");
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Clear data");
+                boolean success = false;
+                try {
+                    Address start = program.getAddressFactory().getAddress(addressStr);
+                    Listing listing = program.getListing();
+
+                    Address end;
+                    if (sizeStr != null && !sizeStr.isEmpty()) {
+                        int size = Integer.parseInt(sizeStr);
+                        end = start.add(size - 1);
+                    } else {
+                        Data data = listing.getDataAt(start);
+                        if (data == null) {
+                            data = listing.getDataContaining(start);
+                        }
+                        if (data != null) {
+                            end = start.add(data.getLength() - 1);
+                        } else {
+                            end = start;
+                        }
+                    }
+
+                    listing.clearCodeUnits(start, end, false);
+                    success = true;
+                    result.set("Cleared data from " + start + " to " + end);
+                } catch (Exception e) {
+                    Msg.error(this, "Error clearing data", e);
+                    result.set("Error clearing data: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (InterruptedException | InvocationTargetException e) {
+            Msg.error(this, "Failed to execute clear data on Swing thread", e);
+        }
+
+        return result.get();
+    }
+
+    private String defineData(String addressStr, String dataTypeName, String label) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (addressStr == null || addressStr.isEmpty()) return "Address is required";
+        if (dataTypeName == null || dataTypeName.isEmpty()) return "Data type is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to define data");
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Define data");
+                boolean success = false;
+                try {
+                    Address addr = program.getAddressFactory().getAddress(addressStr);
+                    DataTypeManager dtm = program.getDataTypeManager();
+                    DataType dt = resolveDataType(dtm, dataTypeName);
+
+                    program.getListing().createData(addr, dt);
+
+                    if (label != null && !label.isEmpty()) {
+                        program.getSymbolTable().createLabel(addr, label, SourceType.USER_DEFINED);
+                    }
+
+                    success = true;
+                    result.set("Defined " + dataTypeName + " at " + addr +
+                              (label != null && !label.isEmpty() ? " with label " + label : ""));
+                } catch (Exception e) {
+                    Msg.error(this, "Error defining data", e);
+                    result.set("Error defining data: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (InterruptedException | InvocationTargetException e) {
+            Msg.error(this, "Failed to execute define data on Swing thread", e);
+        }
+
+        return result.get();
+    }
+
+    private String defineDataBatch(String jsonBody) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (jsonBody == null || jsonBody.isEmpty()) return "JSON body is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to define data batch");
+
+        try {
+            JsonArray items = JsonParser.parseString(jsonBody).getAsJsonArray();
+
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Define data batch");
+                boolean success = false;
+                int succeeded = 0;
+                int failed = 0;
+                StringBuilder errors = new StringBuilder();
+
+                try {
+                    DataTypeManager dtm = program.getDataTypeManager();
+                    Listing listing = program.getListing();
+                    SymbolTable symTable = program.getSymbolTable();
+
+                    for (JsonElement el : items) {
+                        JsonObject item = el.getAsJsonObject();
+                        String addr = item.get("address").getAsString();
+                        String typeName = item.get("data_type").getAsString();
+                        String label = item.has("label") ? item.get("label").getAsString() : null;
+
+                        try {
+                            Address address = program.getAddressFactory().getAddress(addr);
+                            DataType dt = resolveDataType(dtm, typeName);
+                            listing.createData(address, dt);
+
+                            if (label != null && !label.isEmpty()) {
+                                symTable.createLabel(address, label, SourceType.USER_DEFINED);
+                            }
+                            succeeded++;
+                        } catch (Exception e) {
+                            failed++;
+                            errors.append(addr).append(": ").append(e.getMessage()).append("\n");
+                        }
+                    }
+
+                    success = succeeded > 0;
+                    result.set("Total: " + items.size() + ", Succeeded: " + succeeded +
+                              ", Failed: " + failed +
+                              (errors.length() > 0 ? "\nErrors:\n" + errors : ""));
+                } catch (Exception e) {
+                    Msg.error(this, "Error in define data batch", e);
+                    result.set("Error in batch: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (Exception e) {
+            result.set("Error parsing JSON: " + e.getMessage());
+        }
+
+        return result.get();
+    }
+
+    private String readBytes(String addressStr, String lengthStr) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (addressStr == null || addressStr.isEmpty()) return "Address is required";
+        if (lengthStr == null || lengthStr.isEmpty()) return "Length is required";
+
+        try {
+            Address addr = program.getAddressFactory().getAddress(addressStr);
+            int length = Integer.parseInt(lengthStr);
+            byte[] bytes = new byte[length];
+            program.getMemory().getBytes(addr, bytes);
+
+            StringBuilder hex = new StringBuilder();
+            for (byte b : bytes) {
+                hex.append(String.format("%02x", b & 0xFF));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            return "Error reading bytes: " + e.getMessage();
+        }
+    }
+
+    private String getDataAt(String addressStr) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (addressStr == null || addressStr.isEmpty()) return "Address is required";
+
+        try {
+            Address addr = program.getAddressFactory().getAddress(addressStr);
+            Listing listing = program.getListing();
+
+            Data data = listing.getDataAt(addr);
+            String matchType = "exact";
+            if (data == null) {
+                data = listing.getDataContaining(addr);
+                matchType = "containing";
+            }
+
+            if (data == null) {
+                return "No data defined at " + addressStr;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Address: ").append(data.getAddress()).append("\n");
+            sb.append("Match: ").append(matchType).append("\n");
+            sb.append("Type: ").append(data.getDataType().getName()).append("\n");
+            sb.append("Size: ").append(data.getLength()).append(" bytes\n");
+            sb.append("Value: ").append(data.getDefaultValueRepresentation()).append("\n");
+
+            Symbol[] symbols = program.getSymbolTable().getSymbols(data.getAddress());
+            if (symbols.length > 0) {
+                sb.append("Label: ").append(symbols[0].getName()).append("\n");
+            }
+
+            if ("containing".equals(matchType)) {
+                long offset = addr.subtract(data.getAddress());
+                sb.append("Offset within item: ").append(offset).append("\n");
+            }
+
+            return sb.toString();
+        } catch (Exception e) {
+            return "Error getting data: " + e.getMessage();
+        }
+    }
+
+    private String batchRenameFunctions(String jsonBody) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (jsonBody == null || jsonBody.isEmpty()) return "JSON body is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to batch rename");
+
+        try {
+            JsonArray items = JsonParser.parseString(jsonBody).getAsJsonArray();
+
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Batch rename functions");
+                boolean success = false;
+                int succeeded = 0;
+                int failed = 0;
+                StringBuilder errors = new StringBuilder();
+
+                try {
+                    for (JsonElement el : items) {
+                        JsonObject item = el.getAsJsonObject();
+                        String addr = item.get("address").getAsString();
+                        String newName = item.get("new_name").getAsString();
+
+                        try {
+                            Address address = program.getAddressFactory().getAddress(addr);
+                            Function func = getFunctionForAddress(program, address);
+                            if (func == null) {
+                                failed++;
+                                errors.append(addr).append(": No function at address\n");
+                                continue;
+                            }
+                            func.setName(newName, SourceType.USER_DEFINED);
+                            succeeded++;
+                        } catch (Exception e) {
+                            failed++;
+                            errors.append(addr).append(": ").append(e.getMessage()).append("\n");
+                        }
+                    }
+
+                    success = succeeded > 0;
+                    result.set("Total: " + items.size() + ", Succeeded: " + succeeded +
+                              ", Failed: " + failed +
+                              (errors.length() > 0 ? "\nErrors:\n" + errors : ""));
+                } catch (Exception e) {
+                    Msg.error(this, "Error in batch rename", e);
+                    result.set("Error in batch: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (Exception e) {
+            result.set("Error parsing JSON: " + e.getMessage());
+        }
+
+        return result.get();
+    }
+
+    private String batchSetComments(String jsonBody) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (jsonBody == null || jsonBody.isEmpty()) return "JSON body is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to batch set comments");
+
+        try {
+            JsonObject body = JsonParser.parseString(jsonBody).getAsJsonObject();
+            String commentTypeStr = body.has("comment_type") ? body.get("comment_type").getAsString() : "decompiler";
+            int commentType = "disassembly".equalsIgnoreCase(commentTypeStr)
+                    ? CodeUnit.EOL_COMMENT : CodeUnit.PRE_COMMENT;
+            JsonArray comments = body.getAsJsonArray("comments");
+
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Batch set comments");
+                boolean success = false;
+                int succeeded = 0;
+                int failed = 0;
+                StringBuilder errors = new StringBuilder();
+
+                try {
+                    Listing listing = program.getListing();
+
+                    for (JsonElement el : comments) {
+                        JsonObject item = el.getAsJsonObject();
+                        String addr = item.get("address").getAsString();
+                        String comment = item.get("comment").getAsString();
+
+                        try {
+                            Address address = program.getAddressFactory().getAddress(addr);
+                            listing.setComment(address, commentType, comment);
+                            succeeded++;
+                        } catch (Exception e) {
+                            failed++;
+                            errors.append(addr).append(": ").append(e.getMessage()).append("\n");
+                        }
+                    }
+
+                    success = succeeded > 0;
+                    result.set("Total: " + comments.size() + ", Succeeded: " + succeeded +
+                              ", Failed: " + failed +
+                              (errors.length() > 0 ? "\nErrors:\n" + errors : ""));
+                } catch (Exception e) {
+                    Msg.error(this, "Error in batch set comments", e);
+                    result.set("Error in batch: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (Exception e) {
+            result.set("Error parsing JSON: " + e.getMessage());
+        }
+
+        return result.get();
+    }
+
+    private String createLabel(String addressStr, String name, String namespace) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (addressStr == null || addressStr.isEmpty()) return "Address is required";
+        if (name == null || name.isEmpty()) return "Name is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to create label");
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Create label");
+                boolean success = false;
+                try {
+                    Address addr = program.getAddressFactory().getAddress(addressStr);
+                    SymbolTable symTable = program.getSymbolTable();
+
+                    Namespace ns = null;
+                    if (namespace != null && !namespace.isEmpty()) {
+                        ns = symTable.getNamespace(namespace, null);
+                        if (ns == null) {
+                            ns = symTable.createNameSpace(null, namespace, SourceType.USER_DEFINED);
+                        }
+                    }
+
+                    if (ns != null) {
+                        symTable.createLabel(addr, name, ns, SourceType.USER_DEFINED);
+                    } else {
+                        symTable.createLabel(addr, name, SourceType.USER_DEFINED);
+                    }
+
+                    success = true;
+                    result.set("Label '" + name + "' created at " + addr);
+                } catch (Exception e) {
+                    Msg.error(this, "Error creating label", e);
+                    result.set("Error creating label: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (InterruptedException | InvocationTargetException e) {
+            Msg.error(this, "Failed to execute create label on Swing thread", e);
+        }
+
+        return result.get();
+    }
+
+    private String createEnum(String jsonBody) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (jsonBody == null || jsonBody.isEmpty()) return "JSON body is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to create enum");
+
+        try {
+            JsonObject body = JsonParser.parseString(jsonBody).getAsJsonObject();
+            String name = body.get("name").getAsString();
+            int size = body.has("size") ? body.get("size").getAsInt() : 4;
+            JsonArray values = body.getAsJsonArray("values");
+
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Create enum");
+                boolean success = false;
+                try {
+                    DataTypeManager dtm = program.getDataTypeManager();
+                    EnumDataType enumType = new EnumDataType(name, size);
+
+                    for (JsonElement el : values) {
+                        JsonObject entry = el.getAsJsonObject();
+                        String entryName = entry.get("name").getAsString();
+                        long entryValue = entry.get("value").getAsLong();
+                        enumType.add(entryName, entryValue);
+                    }
+
+                    dtm.addDataType(enumType, DataTypeConflictHandler.REPLACE_HANDLER);
+                    success = true;
+                    result.set("Enum '" + name + "' created with " + values.size() + " values");
+                } catch (Exception e) {
+                    Msg.error(this, "Error creating enum", e);
+                    result.set("Error creating enum: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (Exception e) {
+            result.set("Error parsing JSON: " + e.getMessage());
+        }
+
+        return result.get();
+    }
+
+    private String createStruct(String jsonBody) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (jsonBody == null || jsonBody.isEmpty()) return "JSON body is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to create struct");
+
+        try {
+            JsonObject body = JsonParser.parseString(jsonBody).getAsJsonObject();
+            String name = body.get("name").getAsString();
+            JsonArray fields = body.getAsJsonArray("fields");
+
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Create struct");
+                boolean success = false;
+                try {
+                    DataTypeManager dtm = program.getDataTypeManager();
+                    StructureDataType struct = new StructureDataType(name, 0);
+
+                    for (JsonElement el : fields) {
+                        JsonObject field = el.getAsJsonObject();
+                        String fieldName = field.get("name").getAsString();
+                        String fieldType = field.get("type").getAsString();
+                        int fieldSize = field.has("size") ? field.get("size").getAsInt() : 0;
+
+                        DataType dt = resolveDataType(dtm, fieldType);
+                        if (fieldSize > 0) {
+                            struct.add(dt, fieldSize, fieldName, null);
+                        } else {
+                            struct.add(dt, dt.getLength(), fieldName, null);
+                        }
+                    }
+
+                    dtm.addDataType(struct, DataTypeConflictHandler.REPLACE_HANDLER);
+                    success = true;
+                    result.set("Struct '" + name + "' created with " + fields.size() +
+                              " fields, total size: " + struct.getLength() + " bytes");
+                } catch (Exception e) {
+                    Msg.error(this, "Error creating struct", e);
+                    result.set("Error creating struct: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (Exception e) {
+            result.set("Error parsing JSON: " + e.getMessage());
+        }
+
+        return result.get();
+    }
+
+    private String applyStruct(String addressStr, String structName) {
+        Program program = getCurrentProgram();
+        if (program == null) return "No program loaded";
+        if (addressStr == null || addressStr.isEmpty()) return "Address is required";
+        if (structName == null || structName.isEmpty()) return "Struct name is required";
+
+        AtomicReference<String> result = new AtomicReference<>("Failed to apply struct");
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                int tx = program.startTransaction("Apply struct");
+                boolean success = false;
+                try {
+                    Address addr = program.getAddressFactory().getAddress(addressStr);
+                    DataTypeManager dtm = program.getDataTypeManager();
+                    DataType dt = findDataTypeByNameInAllCategories(dtm, structName);
+
+                    if (dt == null) {
+                        result.set("Struct '" + structName + "' not found");
+                        return;
+                    }
+
+                    Listing listing = program.getListing();
+                    // Clear existing data at the address range
+                    listing.clearCodeUnits(addr, addr.add(dt.getLength() - 1), false);
+                    listing.createData(addr, dt);
+
+                    success = true;
+                    result.set("Applied struct '" + structName + "' at " + addr +
+                              " (" + dt.getLength() + " bytes)");
+                } catch (Exception e) {
+                    Msg.error(this, "Error applying struct", e);
+                    result.set("Error applying struct: " + e.getMessage());
+                } finally {
+                    program.endTransaction(tx, success);
+                }
+            });
+        } catch (InterruptedException | InvocationTargetException e) {
+            Msg.error(this, "Failed to execute apply struct on Swing thread", e);
+        }
+
+        return result.get();
+    }
+
     // ----------------------------------------------------------------------------------
     // Utility: parse query params, parse post params, pagination, etc.
     // ----------------------------------------------------------------------------------
@@ -1554,6 +2164,13 @@ public class GhidraMCPPlugin extends Plugin {
             }
         }
         return result;
+    }
+
+    /**
+     * Read raw request body as a string (for JSON endpoints).
+     */
+    private String readRequestBody(HttpExchange exchange) throws IOException {
+        return new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
GhidraMCP can read analysis and rename things, but can't fix Ghidra's auto-analysis mistakes through the API. This adds 11 endpoints that close that gap.

## New endpoints

**Data manipulation:**
- `POST /clear_data` — undefine data at an address
- `POST /define_data` — create a typed data definition with optional label
- `POST /define_data_batch` — define multiple data items in one transaction

**Query and batch operations:**
- `GET /read_bytes` — read raw bytes as hex
- `GET /get_data_at` — inspect the data item at a specific address
- `POST /batch_rename_functions` — rename multiple functions in one call
- `POST /batch_set_comments` — set multiple comments in one call
- `POST /create_label` — create a label at any address

**Type system:**
- `POST /create_enum`, `POST /create_struct`, `POST /apply_struct`

Batch endpoints take JSON bodies (parsed via Ghidra's bundled Gson, no new dependencies) and run in a single transaction with per-item error reporting.

Also extends `resolveDataType` with float/double/qword/pointer, and fixes `getCurrentProgram()` returning null when the plugin is loaded from Code Browser.

All endpoints exposed in the Python MCP bridge.

## Example: fixing a mistyped data region

Ghidra merged a lookup table of 4-byte ASCII tags into one string. Three calls against the Ghidra HTTP server to fix it:

```sh
# Verify contents
curl "http://localhost:8080/read_bytes?address=0x1018e7a8&length=100"

# Clear the blob
curl -X POST -d "address=0x1018e7a8&size=100" http://localhost:8080/clear_data

# Define labeled dwords in one shot
curl -X POST -H "Content-Type: application/json" \
  http://localhost:8080/define_data_batch \
  -d '[{"address":"0x1018e7a8","data_type":"dword","label":"tag_DTBL"},
       {"address":"0x1018e7ac","data_type":"dword","label":"tag_PLNT"}, ...]'
```

Decompiler output goes from `table._16_4_ == id` to `tag_CLIM == id`.