### PR TITLE
Support multiple open programs via optional 'program' selector (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ MCP Server + Ghidra Plugin
 - Decompile and analyze binaries in Ghidra
 - Automatically rename methods and data
 - List methods, classes, imports, and exports
+- Work with multiple binaries open in one Ghidra tool (target each by name)
+
+## Multiple open programs
+
+When several programs are open in the same Ghidra tool, every tool accepts an
+optional `program` argument to select which one to act on. Discover the open
+programs with `list_open_programs` (the focused one is marked `(current)`), then
+pass a name or project path, e.g. `list_methods(program="firmware.sb")`. Leaving
+`program` empty keeps the previous behavior and uses the currently focused
+program, so existing usage is unaffected.
 
 # Installation
 

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -42,13 +42,13 @@ def safe_get(endpoint: str, params: dict = None) -> list:
     except Exception as e:
         return [f"Request failed: {str(e)}"]
 
-def safe_post(endpoint: str, data: dict | str) -> str:
+def safe_post(endpoint: str, data: dict | str, params: dict = None) -> str:
     try:
         url = urljoin(ghidra_server_url, endpoint)
         if isinstance(data, dict):
-            response = requests.post(url, data=data, timeout=5)
+            response = requests.post(url, data=data, params=params, timeout=5)
         else:
-            response = requests.post(url, data=data.encode("utf-8"), timeout=5)
+            response = requests.post(url, data=data.encode("utf-8"), params=params, timeout=5)
         response.encoding = 'utf-8'
         if response.ok:
             return response.text.strip()
@@ -57,102 +57,131 @@ def safe_post(endpoint: str, data: dict | str) -> str:
     except Exception as e:
         return f"Request failed: {str(e)}"
 
+def _with_program(params: dict, program: str) -> dict:
+    """Attach the optional 'program' selector to a params dict when provided."""
+    if program:
+        params = dict(params)
+        params["program"] = program
+    return params
+
+# Note on the `program` argument (present on every tool below):
+# Ghidra can have several binaries open at once. Leave `program` empty ("") to
+# act on the currently focused program (the original behavior). Pass a program
+# name or project path (see list_open_programs) to target a specific binary,
+# so multiple loaded binaries can be analyzed without switching tabs.
+
 @mcp.tool()
-def list_methods(offset: int = 0, limit: int = 100) -> list:
+def list_open_programs() -> list:
+    """
+    List all programs currently open in Ghidra. Each line is
+    "name<TAB>path[<TAB>(current)]". Use a name or path as the `program`
+    argument of other tools to target a specific binary.
+    """
+    return safe_get("list_open_programs")
+
+@mcp.tool()
+def get_current_program() -> str:
+    """
+    Get the name and path of the currently focused program in Ghidra.
+    """
+    return "\n".join(safe_get("get_current_program"))
+
+@mcp.tool()
+def list_methods(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List all function names in the program with pagination.
     """
-    return safe_get("methods", {"offset": offset, "limit": limit})
+    return safe_get("methods", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def list_classes(offset: int = 0, limit: int = 100) -> list:
+def list_classes(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List all namespace/class names in the program with pagination.
     """
-    return safe_get("classes", {"offset": offset, "limit": limit})
+    return safe_get("classes", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def decompile_function(name: str) -> str:
+def decompile_function(name: str, program: str = "") -> str:
     """
     Decompile a specific function by name and return the decompiled C code.
     """
-    return safe_post("decompile", name)
+    return safe_post("decompile", name, _with_program({}, program))
 
 @mcp.tool()
-def rename_function(old_name: str, new_name: str) -> str:
+def rename_function(old_name: str, new_name: str, program: str = "") -> str:
     """
     Rename a function by its current name to a new user-defined name.
     """
-    return safe_post("renameFunction", {"oldName": old_name, "newName": new_name})
+    return safe_post("renameFunction", _with_program({"oldName": old_name, "newName": new_name}, program))
 
 @mcp.tool()
-def rename_data(address: str, new_name: str) -> str:
+def rename_data(address: str, new_name: str, program: str = "") -> str:
     """
     Rename a data label at the specified address.
     """
-    return safe_post("renameData", {"address": address, "newName": new_name})
+    return safe_post("renameData", _with_program({"address": address, "newName": new_name}, program))
 
 @mcp.tool()
-def list_segments(offset: int = 0, limit: int = 100) -> list:
+def list_segments(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List all memory segments in the program with pagination.
     """
-    return safe_get("segments", {"offset": offset, "limit": limit})
+    return safe_get("segments", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def list_imports(offset: int = 0, limit: int = 100) -> list:
+def list_imports(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List imported symbols in the program with pagination.
     """
-    return safe_get("imports", {"offset": offset, "limit": limit})
+    return safe_get("imports", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def list_exports(offset: int = 0, limit: int = 100) -> list:
+def list_exports(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List exported functions/symbols with pagination.
     """
-    return safe_get("exports", {"offset": offset, "limit": limit})
+    return safe_get("exports", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def list_namespaces(offset: int = 0, limit: int = 100) -> list:
+def list_namespaces(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List all non-global namespaces in the program with pagination.
     """
-    return safe_get("namespaces", {"offset": offset, "limit": limit})
+    return safe_get("namespaces", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def list_data_items(offset: int = 0, limit: int = 100) -> list:
+def list_data_items(offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     List defined data labels and their values with pagination.
     """
-    return safe_get("data", {"offset": offset, "limit": limit})
+    return safe_get("data", _with_program({"offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def search_functions_by_name(query: str, offset: int = 0, limit: int = 100) -> list:
+def search_functions_by_name(query: str, offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     Search for functions whose name contains the given substring.
     """
     if not query:
         return ["Error: query string is required"]
-    return safe_get("searchFunctions", {"query": query, "offset": offset, "limit": limit})
+    return safe_get("searchFunctions", _with_program({"query": query, "offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def rename_variable(function_name: str, old_name: str, new_name: str) -> str:
+def rename_variable(function_name: str, old_name: str, new_name: str, program: str = "") -> str:
     """
     Rename a local variable within a function.
     """
-    return safe_post("renameVariable", {
+    return safe_post("renameVariable", _with_program({
         "functionName": function_name,
         "oldName": old_name,
         "newName": new_name
-    })
+    }, program))
 
 @mcp.tool()
-def get_function_by_address(address: str) -> str:
+def get_function_by_address(address: str, program: str = "") -> str:
     """
     Get a function by its address.
     """
-    return "\n".join(safe_get("get_function_by_address", {"address": address}))
+    return "\n".join(safe_get("get_function_by_address", _with_program({"address": address}, program)))
 
 @mcp.tool()
 def get_current_address() -> str:
@@ -169,123 +198,127 @@ def get_current_function() -> str:
     return "\n".join(safe_get("get_current_function"))
 
 @mcp.tool()
-def list_functions() -> list:
+def list_functions(program: str = "") -> list:
     """
     List all functions in the database.
     """
-    return safe_get("list_functions")
+    return safe_get("list_functions", _with_program({}, program))
 
 @mcp.tool()
-def decompile_function_by_address(address: str) -> str:
+def decompile_function_by_address(address: str, program: str = "") -> str:
     """
     Decompile a function at the given address.
     """
-    return "\n".join(safe_get("decompile_function", {"address": address}))
+    return "\n".join(safe_get("decompile_function", _with_program({"address": address}, program)))
 
 @mcp.tool()
-def disassemble_function(address: str) -> list:
+def disassemble_function(address: str, program: str = "") -> list:
     """
     Get assembly code (address: instruction; comment) for a function.
     """
-    return safe_get("disassemble_function", {"address": address})
+    return safe_get("disassemble_function", _with_program({"address": address}, program))
 
 @mcp.tool()
-def set_decompiler_comment(address: str, comment: str) -> str:
+def set_decompiler_comment(address: str, comment: str, program: str = "") -> str:
     """
     Set a comment for a given address in the function pseudocode.
     """
-    return safe_post("set_decompiler_comment", {"address": address, "comment": comment})
+    return safe_post("set_decompiler_comment", _with_program({"address": address, "comment": comment}, program))
 
 @mcp.tool()
-def set_disassembly_comment(address: str, comment: str) -> str:
+def set_disassembly_comment(address: str, comment: str, program: str = "") -> str:
     """
     Set a comment for a given address in the function disassembly.
     """
-    return safe_post("set_disassembly_comment", {"address": address, "comment": comment})
+    return safe_post("set_disassembly_comment", _with_program({"address": address, "comment": comment}, program))
 
 @mcp.tool()
-def rename_function_by_address(function_address: str, new_name: str) -> str:
+def rename_function_by_address(function_address: str, new_name: str, program: str = "") -> str:
     """
     Rename a function by its address.
     """
-    return safe_post("rename_function_by_address", {"function_address": function_address, "new_name": new_name})
+    return safe_post("rename_function_by_address", _with_program({"function_address": function_address, "new_name": new_name}, program))
 
 @mcp.tool()
-def set_function_prototype(function_address: str, prototype: str) -> str:
+def set_function_prototype(function_address: str, prototype: str, program: str = "") -> str:
     """
     Set a function's prototype.
     """
-    return safe_post("set_function_prototype", {"function_address": function_address, "prototype": prototype})
+    return safe_post("set_function_prototype", _with_program({"function_address": function_address, "prototype": prototype}, program))
 
 @mcp.tool()
-def set_local_variable_type(function_address: str, variable_name: str, new_type: str) -> str:
+def set_local_variable_type(function_address: str, variable_name: str, new_type: str, program: str = "") -> str:
     """
     Set a local variable's type.
     """
-    return safe_post("set_local_variable_type", {"function_address": function_address, "variable_name": variable_name, "new_type": new_type})
+    return safe_post("set_local_variable_type", _with_program({"function_address": function_address, "variable_name": variable_name, "new_type": new_type}, program))
 
 @mcp.tool()
-def get_xrefs_to(address: str, offset: int = 0, limit: int = 100) -> list:
+def get_xrefs_to(address: str, offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     Get all references to the specified address (xref to).
-    
+
     Args:
         address: Target address in hex format (e.g. "0x1400010a0")
         offset: Pagination offset (default: 0)
         limit: Maximum number of references to return (default: 100)
-        
+        program: Optional program selector (see list_open_programs); empty = current
+
     Returns:
         List of references to the specified address
     """
-    return safe_get("xrefs_to", {"address": address, "offset": offset, "limit": limit})
+    return safe_get("xrefs_to", _with_program({"address": address, "offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def get_xrefs_from(address: str, offset: int = 0, limit: int = 100) -> list:
+def get_xrefs_from(address: str, offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     Get all references from the specified address (xref from).
-    
+
     Args:
         address: Source address in hex format (e.g. "0x1400010a0")
         offset: Pagination offset (default: 0)
         limit: Maximum number of references to return (default: 100)
-        
+        program: Optional program selector (see list_open_programs); empty = current
+
     Returns:
         List of references from the specified address
     """
-    return safe_get("xrefs_from", {"address": address, "offset": offset, "limit": limit})
+    return safe_get("xrefs_from", _with_program({"address": address, "offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def get_function_xrefs(name: str, offset: int = 0, limit: int = 100) -> list:
+def get_function_xrefs(name: str, offset: int = 0, limit: int = 100, program: str = "") -> list:
     """
     Get all references to the specified function by name.
-    
+
     Args:
         name: Function name to search for
         offset: Pagination offset (default: 0)
         limit: Maximum number of references to return (default: 100)
-        
+        program: Optional program selector (see list_open_programs); empty = current
+
     Returns:
         List of references to the specified function
     """
-    return safe_get("function_xrefs", {"name": name, "offset": offset, "limit": limit})
+    return safe_get("function_xrefs", _with_program({"name": name, "offset": offset, "limit": limit}, program))
 
 @mcp.tool()
-def list_strings(offset: int = 0, limit: int = 2000, filter: str = None) -> list:
+def list_strings(offset: int = 0, limit: int = 2000, filter: str = None, program: str = "") -> list:
     """
     List all defined strings in the program with their addresses.
-    
+
     Args:
         offset: Pagination offset (default: 0)
         limit: Maximum number of strings to return (default: 2000)
         filter: Optional filter to match within string content
-        
+        program: Optional program selector (see list_open_programs); empty = current
+
     Returns:
         List of strings with their addresses
     """
     params = {"offset": offset, "limit": limit}
     if filter:
         params["filter"] = filter
-    return safe_get("strings", params)
+    return safe_get("strings", _with_program(params, program))
 
 def main():
     parser = argparse.ArgumentParser(description="MCP server for Ghidra")
@@ -298,12 +331,12 @@ def main():
     parser.add_argument("--transport", type=str, default="stdio", choices=["stdio", "sse"],
                         help="Transport protocol for MCP, default: stdio")
     args = parser.parse_args()
-    
+
     # Use the global variable to ensure it's properly updated
     global ghidra_server_url
     if args.ghidra_server:
         ghidra_server_url = args.ghidra_server
-    
+
     if args.transport == "sse":
         try:
             # Set up logging
@@ -332,7 +365,6 @@ def main():
             logger.info("Server stopped by user")
     else:
         mcp.run()
-        
+
 if __name__ == "__main__":
     main()
-

--- a/src/main/java/com/lauriewired/GhidraMCPPlugin.java
+++ b/src/main/java/com/lauriewired/GhidraMCPPlugin.java
@@ -111,31 +111,32 @@ public class GhidraMCPPlugin extends Plugin {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, getAllFunctionNames(offset, limit));
+            sendResponse(exchange, getAllFunctionNames(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/classes", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, getAllClassNames(offset, limit));
+            sendResponse(exchange, getAllClassNames(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/decompile", exchange -> {
+            Map<String, String> qparams = parseQueryParams(exchange);
             String name = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
-            sendResponse(exchange, decompileFunctionByName(name));
+            sendResponse(exchange, decompileFunctionByName(qparams.get("program"), name));
         });
 
         server.createContext("/renameFunction", exchange -> {
             Map<String, String> params = parsePostParams(exchange);
-            String response = renameFunction(params.get("oldName"), params.get("newName"))
+            String response = renameFunction(params.get("program"), params.get("oldName"), params.get("newName"))
                     ? "Renamed successfully" : "Rename failed";
             sendResponse(exchange, response);
         });
 
         server.createContext("/renameData", exchange -> {
             Map<String, String> params = parsePostParams(exchange);
-            renameDataAtAddress(params.get("address"), params.get("newName"));
+            renameDataAtAddress(params.get("program"), params.get("address"), params.get("newName"));
             sendResponse(exchange, "Rename data attempted");
         });
 
@@ -144,7 +145,7 @@ public class GhidraMCPPlugin extends Plugin {
             String functionName = params.get("functionName");
             String oldName = params.get("oldName");
             String newName = params.get("newName");
-            String result = renameVariableInFunction(functionName, oldName, newName);
+            String result = renameVariableInFunction(params.get("program"), functionName, oldName, newName);
             sendResponse(exchange, result);
         });
 
@@ -152,35 +153,35 @@ public class GhidraMCPPlugin extends Plugin {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, listSegments(offset, limit));
+            sendResponse(exchange, listSegments(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/imports", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, listImports(offset, limit));
+            sendResponse(exchange, listImports(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/exports", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, listExports(offset, limit));
+            sendResponse(exchange, listExports(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/namespaces", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, listNamespaces(offset, limit));
+            sendResponse(exchange, listNamespaces(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/data", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit  = parseIntOrDefault(qparams.get("limit"),  100);
-            sendResponse(exchange, listDefinedData(offset, limit));
+            sendResponse(exchange, listDefinedData(qparams.get("program"), offset, limit));
         });
 
         server.createContext("/searchFunctions", exchange -> {
@@ -188,7 +189,7 @@ public class GhidraMCPPlugin extends Plugin {
             String searchTerm = qparams.get("query");
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit = parseIntOrDefault(qparams.get("limit"), 100);
-            sendResponse(exchange, searchFunctionsByName(searchTerm, offset, limit));
+            sendResponse(exchange, searchFunctionsByName(qparams.get("program"), searchTerm, offset, limit));
         });
 
         // New API endpoints based on requirements
@@ -196,7 +197,7 @@ public class GhidraMCPPlugin extends Plugin {
         server.createContext("/get_function_by_address", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             String address = qparams.get("address");
-            sendResponse(exchange, getFunctionByAddress(address));
+            sendResponse(exchange, getFunctionByAddress(qparams.get("program"), address));
         });
 
         server.createContext("/get_current_address", exchange -> {
@@ -207,27 +208,39 @@ public class GhidraMCPPlugin extends Plugin {
             sendResponse(exchange, getCurrentFunction());
         });
 
+        server.createContext("/list_open_programs", exchange -> {
+            sendResponse(exchange, listOpenPrograms());
+        });
+
+        server.createContext("/get_current_program", exchange -> {
+            Program program = getCurrentProgram();
+            sendResponse(exchange, program != null
+                ? program.getName() + "\t" + program.getDomainFile().getPathname()
+                : "No program loaded");
+        });
+
         server.createContext("/list_functions", exchange -> {
-            sendResponse(exchange, listFunctions());
+            Map<String, String> qparams = parseQueryParams(exchange);
+            sendResponse(exchange, listFunctions(qparams.get("program")));
         });
 
         server.createContext("/decompile_function", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             String address = qparams.get("address");
-            sendResponse(exchange, decompileFunctionByAddress(address));
+            sendResponse(exchange, decompileFunctionByAddress(qparams.get("program"), address));
         });
 
         server.createContext("/disassemble_function", exchange -> {
             Map<String, String> qparams = parseQueryParams(exchange);
             String address = qparams.get("address");
-            sendResponse(exchange, disassembleFunction(address));
+            sendResponse(exchange, disassembleFunction(qparams.get("program"), address));
         });
 
         server.createContext("/set_decompiler_comment", exchange -> {
             Map<String, String> params = parsePostParams(exchange);
             String address = params.get("address");
             String comment = params.get("comment");
-            boolean success = setDecompilerComment(address, comment);
+            boolean success = setDecompilerComment(params.get("program"), address, comment);
             sendResponse(exchange, success ? "Comment set successfully" : "Failed to set comment");
         });
 
@@ -235,7 +248,7 @@ public class GhidraMCPPlugin extends Plugin {
             Map<String, String> params = parsePostParams(exchange);
             String address = params.get("address");
             String comment = params.get("comment");
-            boolean success = setDisassemblyComment(address, comment);
+            boolean success = setDisassemblyComment(params.get("program"), address, comment);
             sendResponse(exchange, success ? "Comment set successfully" : "Failed to set comment");
         });
 
@@ -243,7 +256,7 @@ public class GhidraMCPPlugin extends Plugin {
             Map<String, String> params = parsePostParams(exchange);
             String functionAddress = params.get("function_address");
             String newName = params.get("new_name");
-            boolean success = renameFunctionByAddress(functionAddress, newName);
+            boolean success = renameFunctionByAddress(params.get("program"), functionAddress, newName);
             sendResponse(exchange, success ? "Function renamed successfully" : "Failed to rename function");
         });
 
@@ -253,7 +266,7 @@ public class GhidraMCPPlugin extends Plugin {
             String prototype = params.get("prototype");
 
             // Call the set prototype function and get detailed result
-            PrototypeResult result = setFunctionPrototype(functionAddress, prototype);
+            PrototypeResult result = setFunctionPrototype(params.get("program"), functionAddress, prototype);
 
             if (result.isSuccess()) {
                 // Even with successful operations, include any warning messages for debugging
@@ -281,7 +294,7 @@ public class GhidraMCPPlugin extends Plugin {
                       .append(" in function at ").append(functionAddress).append("\n\n");
 
             // Attempt to find the data type in various categories
-            Program program = getCurrentProgram();
+            Program program = getProgramByName(params.get("program"));
             if (program != null) {
                 DataTypeManager dtm = program.getDataTypeManager();
                 DataType directType = findDataTypeByNameInAllCategories(dtm, newType);
@@ -301,7 +314,7 @@ public class GhidraMCPPlugin extends Plugin {
             }
 
             // Try to set the type
-            boolean success = setLocalVariableType(functionAddress, variableName, newType);
+            boolean success = setLocalVariableType(program, functionAddress, variableName, newType);
 
             String successMsg = success ? "Variable type set successfully" : "Failed to set variable type";
             responseMsg.append("\nResult: ").append(successMsg);
@@ -314,7 +327,7 @@ public class GhidraMCPPlugin extends Plugin {
             String address = qparams.get("address");
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit = parseIntOrDefault(qparams.get("limit"), 100);
-            sendResponse(exchange, getXrefsTo(address, offset, limit));
+            sendResponse(exchange, getXrefsTo(qparams.get("program"), address, offset, limit));
         });
 
         server.createContext("/xrefs_from", exchange -> {
@@ -322,7 +335,7 @@ public class GhidraMCPPlugin extends Plugin {
             String address = qparams.get("address");
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit = parseIntOrDefault(qparams.get("limit"), 100);
-            sendResponse(exchange, getXrefsFrom(address, offset, limit));
+            sendResponse(exchange, getXrefsFrom(qparams.get("program"), address, offset, limit));
         });
 
         server.createContext("/function_xrefs", exchange -> {
@@ -330,7 +343,7 @@ public class GhidraMCPPlugin extends Plugin {
             String name = qparams.get("name");
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit = parseIntOrDefault(qparams.get("limit"), 100);
-            sendResponse(exchange, getFunctionXrefs(name, offset, limit));
+            sendResponse(exchange, getFunctionXrefs(qparams.get("program"), name, offset, limit));
         });
 
         server.createContext("/strings", exchange -> {
@@ -338,7 +351,7 @@ public class GhidraMCPPlugin extends Plugin {
             int offset = parseIntOrDefault(qparams.get("offset"), 0);
             int limit = parseIntOrDefault(qparams.get("limit"), 100);
             String filter = qparams.get("filter");
-            sendResponse(exchange, listDefinedStrings(offset, limit, filter));
+            sendResponse(exchange, listDefinedStrings(qparams.get("program"), offset, limit, filter));
         });
 
         server.setExecutor(null);
@@ -357,8 +370,8 @@ public class GhidraMCPPlugin extends Plugin {
     // Pagination-aware listing methods
     // ----------------------------------------------------------------------------------
 
-    private String getAllFunctionNames(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String getAllFunctionNames(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         List<String> names = new ArrayList<>();
@@ -368,8 +381,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(names, offset, limit);
     }
 
-    private String getAllClassNames(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String getAllClassNames(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         Set<String> classNames = new HashSet<>();
@@ -385,8 +398,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(sorted, offset, limit);
     }
 
-    private String listSegments(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String listSegments(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         List<String> lines = new ArrayList<>();
@@ -396,8 +409,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(lines, offset, limit);
     }
 
-    private String listImports(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String listImports(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         List<String> lines = new ArrayList<>();
@@ -407,8 +420,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(lines, offset, limit);
     }
 
-    private String listExports(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String listExports(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         SymbolTable table = program.getSymbolTable();
@@ -425,8 +438,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(lines, offset, limit);
     }
 
-    private String listNamespaces(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String listNamespaces(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         Set<String> namespaces = new HashSet<>();
@@ -441,8 +454,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(sorted, offset, limit);
     }
 
-    private String listDefinedData(int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String listDefinedData(String programName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         List<String> lines = new ArrayList<>();
@@ -464,8 +477,8 @@ public class GhidraMCPPlugin extends Plugin {
         return paginateList(lines, offset, limit);
     }
 
-    private String searchFunctionsByName(String searchTerm, int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String searchFunctionsByName(String programName, String searchTerm, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (searchTerm == null || searchTerm.isEmpty()) return "Search term is required";
     
@@ -490,8 +503,8 @@ public class GhidraMCPPlugin extends Plugin {
     // Logic for rename, decompile, etc.
     // ----------------------------------------------------------------------------------
 
-    private String decompileFunctionByName(String name) {
-        Program program = getCurrentProgram();
+    private String decompileFunctionByName(String programName, String name) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         DecompInterface decomp = new DecompInterface();
         decomp.openProgram(program);
@@ -509,8 +522,8 @@ public class GhidraMCPPlugin extends Plugin {
         return "Function not found";
     }
 
-    private boolean renameFunction(String oldName, String newName) {
-        Program program = getCurrentProgram();
+    private boolean renameFunction(String programName, String oldName, String newName) {
+        Program program = getProgramByName(programName);
         if (program == null) return false;
 
         AtomicBoolean successFlag = new AtomicBoolean(false);
@@ -540,8 +553,8 @@ public class GhidraMCPPlugin extends Plugin {
         return successFlag.get();
     }
 
-    private void renameDataAtAddress(String addressStr, String newName) {
-        Program program = getCurrentProgram();
+    private void renameDataAtAddress(String programName, String addressStr, String newName) {
+        Program program = getProgramByName(programName);
         if (program == null) return;
 
         try {
@@ -574,8 +587,8 @@ public class GhidraMCPPlugin extends Plugin {
         }
     }
 
-    private String renameVariableInFunction(String functionName, String oldVarName, String newVarName) {
-        Program program = getCurrentProgram();
+    private String renameVariableInFunction(String programName, String functionName, String oldVarName, String newVarName) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         DecompInterface decomp = new DecompInterface();
@@ -706,8 +719,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Get function by address
      */
-    private String getFunctionByAddress(String addressStr) {
-        Program program = getCurrentProgram();
+    private String getFunctionByAddress(String programName, String addressStr) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (addressStr == null || addressStr.isEmpty()) return "Address is required";
 
@@ -765,8 +778,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * List all functions in the database
      */
-    private String listFunctions() {
-        Program program = getCurrentProgram();
+    private String listFunctions(String programName) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         StringBuilder result = new StringBuilder();
@@ -794,8 +807,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Decompile a function at the given address
      */
-    private String decompileFunctionByAddress(String addressStr) {
-        Program program = getCurrentProgram();
+    private String decompileFunctionByAddress(String programName, String addressStr) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (addressStr == null || addressStr.isEmpty()) return "Address is required";
 
@@ -819,8 +832,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Get assembly code for a function
      */
-    private String disassembleFunction(String addressStr) {
-        Program program = getCurrentProgram();
+    private String disassembleFunction(String programName, String addressStr) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (addressStr == null || addressStr.isEmpty()) return "Address is required";
 
@@ -858,8 +871,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Set a comment using the specified comment type (PRE_COMMENT or EOL_COMMENT)
      */
-    private boolean setCommentAtAddress(String addressStr, String comment, int commentType, String transactionName) {
-        Program program = getCurrentProgram();
+    private boolean setCommentAtAddress(String programName, String addressStr, String comment, int commentType, String transactionName) {
+        Program program = getProgramByName(programName);
         if (program == null) return false;
         if (addressStr == null || addressStr.isEmpty() || comment == null) return false;
 
@@ -888,15 +901,15 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Set a comment for a given address in the function pseudocode
      */
-    private boolean setDecompilerComment(String addressStr, String comment) {
-        return setCommentAtAddress(addressStr, comment, CodeUnit.PRE_COMMENT, "Set decompiler comment");
+    private boolean setDecompilerComment(String programName, String addressStr, String comment) {
+        return setCommentAtAddress(programName, addressStr, comment, CodeUnit.PRE_COMMENT, "Set decompiler comment");
     }
 
     /**
      * Set a comment for a given address in the function disassembly
      */
-    private boolean setDisassemblyComment(String addressStr, String comment) {
-        return setCommentAtAddress(addressStr, comment, CodeUnit.EOL_COMMENT, "Set disassembly comment");
+    private boolean setDisassemblyComment(String programName, String addressStr, String comment) {
+        return setCommentAtAddress(programName, addressStr, comment, CodeUnit.EOL_COMMENT, "Set disassembly comment");
     }
 
     /**
@@ -923,8 +936,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Rename a function by its address
      */
-    private boolean renameFunctionByAddress(String functionAddrStr, String newName) {
-        Program program = getCurrentProgram();
+    private boolean renameFunctionByAddress(String programName, String functionAddrStr, String newName) {
+        Program program = getProgramByName(programName);
         if (program == null) return false;
         if (functionAddrStr == null || functionAddrStr.isEmpty() || 
             newName == null || newName.isEmpty()) {
@@ -970,9 +983,9 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Set a function's prototype with proper error handling using ApplyFunctionSignatureCmd
      */
-    private PrototypeResult setFunctionPrototype(String functionAddrStr, String prototype) {
+    private PrototypeResult setFunctionPrototype(String programName, String functionAddrStr, String prototype) {
         // Input validation
-        Program program = getCurrentProgram();
+        Program program = getProgramByName(programName);
         if (program == null) return new PrototypeResult(false, "No program loaded");
         if (functionAddrStr == null || functionAddrStr.isEmpty()) {
             return new PrototypeResult(false, "Function address is required");
@@ -1101,9 +1114,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Set a local variable's type using HighFunctionDBUtil.updateDBVariable
      */
-    private boolean setLocalVariableType(String functionAddrStr, String variableName, String newType) {
+    private boolean setLocalVariableType(Program program, String functionAddrStr, String variableName, String newType) {
         // Input validation
-        Program program = getCurrentProgram();
         if (program == null) return false;
         if (functionAddrStr == null || functionAddrStr.isEmpty() || 
             variableName == null || variableName.isEmpty() ||
@@ -1245,8 +1257,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Get all references to a specific address (xref to)
      */
-    private String getXrefsTo(String addressStr, int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String getXrefsTo(String programName, String addressStr, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (addressStr == null || addressStr.isEmpty()) return "Address is required";
 
@@ -1277,8 +1289,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Get all references from a specific address (xref from)
      */
-    private String getXrefsFrom(String addressStr, int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String getXrefsFrom(String programName, String addressStr, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (addressStr == null || addressStr.isEmpty()) return "Address is required";
 
@@ -1316,8 +1328,8 @@ public class GhidraMCPPlugin extends Plugin {
     /**
      * Get all references to a specific function by name
      */
-    private String getFunctionXrefs(String functionName, int offset, int limit) {
-        Program program = getCurrentProgram();
+    private String getFunctionXrefs(String programName, String functionName, int offset, int limit) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
         if (functionName == null || functionName.isEmpty()) return "Function name is required";
 
@@ -1355,8 +1367,8 @@ public class GhidraMCPPlugin extends Plugin {
 /**
  * List all defined strings in the program with their addresses
  */
-    private String listDefinedStrings(int offset, int limit, String filter) {
-        Program program = getCurrentProgram();
+    private String listDefinedStrings(String programName, int offset, int limit, String filter) {
+        Program program = getProgramByName(programName);
         if (program == null) return "No program loaded";
 
         List<String> lines = new ArrayList<>();
@@ -1627,6 +1639,50 @@ public class GhidraMCPPlugin extends Plugin {
     public Program getCurrentProgram() {
         ProgramManager pm = tool.getService(ProgramManager.class);
         return pm != null ? pm.getCurrentProgram() : null;
+    }
+
+    /**
+     * Resolve a program among the tool's open programs by name or domain-file path.
+     * When {@code programName} is null or empty this falls back to the current
+     * (focused) program, preserving the previous single-program behavior.
+     *
+     * @param programName a program name (e.g. "ping"), domain-file name, or full
+     *                    project path (e.g. "/folder/ping"); null/empty for current
+     * @return the matching open Program, or null if none matches
+     */
+    private Program getProgramByName(String programName) {
+        ProgramManager pm = tool.getService(ProgramManager.class);
+        if (pm == null) return null;
+        if (programName == null || programName.isEmpty()) {
+            return pm.getCurrentProgram();
+        }
+        for (Program p : pm.getAllOpenPrograms()) {
+            if (p.getName().equals(programName)
+                    || p.getDomainFile().getName().equals(programName)
+                    || p.getDomainFile().getPathname().equals(programName)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * List every program currently open in the tool, marking the focused one.
+     * Each line is "name\tpath[\t(current)]".
+     */
+    private String listOpenPrograms() {
+        ProgramManager pm = tool.getService(ProgramManager.class);
+        if (pm == null) return "Program manager not available";
+
+        Program current = pm.getCurrentProgram();
+        List<String> lines = new ArrayList<>();
+        for (Program p : pm.getAllOpenPrograms()) {
+            String marker = (p == current) ? "\t(current)" : "";
+            lines.add(String.format("%s\t%s%s",
+                p.getName(), p.getDomainFile().getPathname(), marker));
+        }
+        if (lines.isEmpty()) return "No programs open";
+        return String.join("\n", lines);
     }
 
     private void sendResponse(HttpExchange exchange, String response) throws IOException {


### PR DESCRIPTION
Currently every endpoint operates on `ProgramManager.getCurrentProgram()`, so when several binaries are open in one Ghidra tool the server can only ever see the focused tab. This addresses the in-tool half of #15.

## Changes
- Add `getProgramByName(name)` resolving against `getAllOpenPrograms()` by name, domain-file name, or project path; an empty name falls back to the current program, so existing behavior is fully preserved.
- New endpoints/tools: `list_open_programs` (marks the focused program with `(current)`) and `get_current_program`.
- Thread an optional `program` argument through all existing endpoints (HTTP) and MCP tools (Python bridge).
- README section documenting the selector.

## Backward compatibility
Omitting `program` (empty string) reproduces the previous single-program behavior exactly, so existing clients are unaffected.

## Testing
Built against Ghidra 12.0.4. With an ARM firmware and a Windows PE open in the same tool:
- `list_open_programs` reports both, marking the focused one.
- Passing `program=firmware.sb` vs `program=HP39gII.exe` returns each binary's own functions / segments / imports / decompilation, regardless of which tab is focused.
- Omitting `program` matches the focused program.
- An unknown program name degrades gracefully ("No program loaded").

Note: this is the in-tool multi-program case; the separate-tool port-binding case from #15 is out of scope here.