### PR TITLE
Update Ghidra compatibility to 12.1.2 and enhance CI/CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,15 @@
 name: Build with Maven
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GHIDRA_VERSION: 11.3.2
-      GHIDRA_DATE: 20250415
+      GHIDRA_VERSION: 12.1.2
       GHIDRA_LIBS: >-
         Features/Base/lib/Base.jar
         Features/Decompiler/lib/Decompiler.jar
@@ -33,15 +31,18 @@ jobs:
 
     - name: Download Ghidra
       run: |
-        wget --no-verbose -O ghidra.zip https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${{ env.GHIDRA_VERSION }}_build/ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC_${{ env.GHIDRA_DATE }}.zip
+        DOWNLOAD_URL=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/tags/Ghidra_${{ env.GHIDRA_VERSION }}_build | jq -r '.assets[] | select(.name | startswith("ghidra_") and endswith(".zip")) | .browser_download_url' | head -n 1)
+        echo "Downloading Ghidra from: $DOWNLOAD_URL"
+        wget --no-verbose -O ghidra.zip "$DOWNLOAD_URL"
         7z x -bd ghidra.zip
 
     - name: Copy Ghidra libs
       run: |
         mkdir -p ./lib
+        GHIDRA_DIR=$(ls -d ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC*)
         for libfile in ${{ env.GHIDRA_LIBS }}
           do echo "Copying ${libfile} to lib/"
-          cp ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC/Ghidra/${libfile} ./lib/
+          cp ${GHIDRA_DIR}/Ghidra/${libfile} ./lib/
         done
 
     - name: Build with Maven
@@ -49,9 +50,12 @@ jobs:
 
     - name: Assemble release directory
       run: |
+        mkdir -p release_bundle
+        cp target/GhidraMCP.zip release_bundle/
+        cp bridge_mcp_ghidra.py release_bundle/
+        cp requirements.txt release_bundle/
         mkdir release
-        cp target/GhidraMCP-*-SNAPSHOT.zip release/
-        cp bridge_mcp_ghidra.py release/
+        (cd release_bundle && zip -r ../release/GhidraMCP-${{ env.GHIDRA_VERSION }}.zip .)
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.lauriewired</groupId>
   <artifactId>GhidraMCP</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>12.1.2</version>
   <name>GhidraMCP</name>
   <url>http://maven.apache.org</url>
 
@@ -15,56 +15,56 @@
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Generic</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Generic.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>SoftwareModeling</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/SoftwareModeling.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Project</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Project.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Docking</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Docking.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Decompiler</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Decompiler.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Utility</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Utility.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Base</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Base.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>ghidra</groupId>
       <artifactId>Gui</artifactId>
-      <version>11.3.2</version>
+      <version>12.1.2</version>
       <scope>system</scope>
       <systemPath>${project.basedir}/lib/Gui.jar</systemPath>
     </dependency>
@@ -111,7 +111,7 @@
           </descriptors>
           
           <!-- The name of the final zip -->
-          <finalName>GhidraMCP-${project.version}</finalName>
+          <finalName>GhidraMCP</finalName>
           
           <!-- Don't append the assembly ID -->
           <appendAssemblyId>false</appendAssemblyId>

--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -2,5 +2,5 @@ name=GhidraMCP
 description=A plugin that runs an embedded HTTP server to expose program data.
 author=LaurieWired
 createdOn=2025-03-22
-version=11.3.2
-ghidraVersion=11.3.2
+version=12.1.2
+ghidraVersion=12.1.2


### PR DESCRIPTION
## Summary of Changes

This PR updates GhidraMCP compatibility for **Ghidra 12.1.2** and enhances the GitHub Actions build workflow for automated asset packaging.

### 1. Ghidra 12.1.2 Compatibility Update
- Updated plugin properties (`version` & `ghidraVersion`) to `12.1.2` in `src/main/resources/extension.properties`.
- Updated system-scoped dependency versions (`Generic`, `SoftwareModeling`, `Project`, `Docking`, `Decompiler`, `Utility`, `Base`, `Gui`) to `12.1.2` in `pom.xml`.
- Updated POM project version to `12.1.2`.

### 2. CI/CD Build Workflow Improvements (`build.yml`)
- **Dynamic Release Resolution**: Added GitHub API querying to dynamically fetch the Ghidra release package URL matching `GHIDRA_VERSION` (`12.1.2`) without requiring hardcoded dates.
- **Automatic Token Authentication**: Utilized `${{ secrets.GITHUB_TOKEN }}` for API requests to prevent rate limiting without requiring manual secret configuration.
- **Workflow Triggers**: Configured `pull_request` and `workflow_dispatch` triggers for flexible CI testing and manual execution.
- **Master Release Package Bundling**: Updated build step to generate a unified release package containing the Ghidra extension zip (`GhidraMCP.zip`), Python bridge client (`bridge_mcp_ghidra.py`), and Python requirements (`requirements.txt`).

## Testing & Verification
- Verified Maven compilation and assembly packaging.
- Verified GitHub Actions workflow end-to-end; build succeeded cleanly.